### PR TITLE
Support passing numbers to get()

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -62,8 +62,8 @@ declare global {
   }
 
   class Effect {
-    static get(name: string): Effect;
-    static get(names: string[]): Effect[];
+    static get(nameOrId: number | string): Effect;
+    static get(namesAndIds: (number | string)[]): Effect[];
     static all(): Effect[];
     /** Name */
     readonly name: string;
@@ -94,8 +94,8 @@ declare global {
   }
 
   class Familiar {
-    static get(name: string): Familiar;
-    static get(names: string[]): Familiar[];
+    static get(nameOrId: number | string): Familiar;
+    static get(namesAndIds: (number | string)[]): Familiar[];
     static all(): Familiar[];
     /** Hatchling */
     readonly hatchling: Item;
@@ -174,8 +174,8 @@ declare global {
   }
 
   class Item {
-    static get(name: string): Item;
-    static get(names: string[]): Item[];
+    static get(nameOrId: number | string): Item;
+    static get(namesAndIds: (number | string)[]): Item[];
     static all(): Item[];
     /** The name of this Item. */
     readonly name: string;
@@ -303,8 +303,8 @@ declare global {
   }
 
   class Monster {
-    static get(name: string): Monster;
-    static get(names: string[]): Monster[];
+    static get(nameOrId: number | string): Monster;
+    static get(namesAndIds: (number | string)[]): Monster[];
     static all(): Monster[];
     /** Name */
     readonly name: string;
@@ -375,8 +375,8 @@ declare global {
   }
 
   class Servant {
-    static get(name: string): Servant;
-    static get(names: string[]): Servant[];
+    static get(nameOrId: number | string): Servant;
+    static get(namesAndIds: (number | string)[]): Servant[];
     static all(): Servant[];
     /** Id */
     readonly id: number;
@@ -399,8 +399,8 @@ declare global {
   }
 
   class Skill {
-    static get(name: string): Skill;
-    static get(names: string[]): Skill[];
+    static get(nameOrId: number | string): Skill;
+    static get(namesAndIds: (number | string)[]): Skill[];
     static all(): Skill[];
     /** Name */
     readonly name: string;
@@ -439,8 +439,8 @@ declare global {
   }
 
   class Thrall {
-    static get(name: string): Thrall;
-    static get(names: string[]): Thrall[];
+    static get(nameOrId: number | string): Thrall;
+    static get(namesAndIds: (number | string)[]): Thrall[];
     static all(): Thrall[];
     /** Id */
     readonly id: number;

--- a/test-d/global.test-d.ts
+++ b/test-d/global.test-d.ts
@@ -39,7 +39,8 @@ expectError(Coinmaster.get(Symbol('foo')));
 expectError(Coinmaster.get({}));
 
 expectType<Effect>(Effect.get('foo'));
-expectType<Effect[]>(Effect.get(['foo', 'bar']));
+expectType<Effect>(Effect.get(5));
+expectType<Effect[]>(Effect.get(['foo', 'bar', 123]));
 expectType<Effect[]>(Effect.all());
 
 expectError(Effect.get());
@@ -61,7 +62,8 @@ expectError(Element.get(Symbol('foo')));
 expectError(Element.get({}));
 
 expectType<Familiar>(Familiar.get('foo'));
-expectType<Familiar[]>(Familiar.get(['foo', 'bar']));
+expectType<Familiar>(Familiar.get(5));
+expectType<Familiar[]>(Familiar.get(['foo', 'bar', 123]));
 expectType<Familiar[]>(Familiar.all());
 
 expectError(Familiar.get());
@@ -72,7 +74,8 @@ expectError(Familiar.get(Symbol('foo')));
 expectError(Familiar.get({}));
 
 expectType<Item>(Item.get('foo'));
-expectType<Item[]>(Item.get(['foo', 'bar']));
+expectType<Item>(Item.get(5));
+expectType<Item[]>(Item.get(['foo', 'bar', 123]));
 expectType<Item[]>(Item.all());
 
 expectError(Item.get());
@@ -94,7 +97,8 @@ expectError(Location.get(Symbol('foo')));
 expectError(Location.get({}));
 
 expectType<Monster>(Monster.get('foo'));
-expectType<Monster[]>(Monster.get(['foo', 'bar']));
+expectType<Monster>(Monster.get(5));
+expectType<Monster[]>(Monster.get(['foo', 'bar', 123]));
 expectType<Monster[]>(Monster.all());
 
 expectError(Monster.get());
@@ -116,7 +120,8 @@ expectError(Phylum.get(Symbol('foo')));
 expectError(Phylum.get({}));
 
 expectType<Servant>(Servant.get('foo'));
-expectType<Servant[]>(Servant.get(['foo', 'bar']));
+expectType<Servant>(Servant.get(5));
+expectType<Servant[]>(Servant.get(['foo', 'bar', 123]));
 expectType<Servant[]>(Servant.all());
 
 expectError(Servant.get());
@@ -127,7 +132,8 @@ expectError(Servant.get(Symbol('foo')));
 expectError(Servant.get({}));
 
 expectType<Skill>(Skill.get('foo'));
-expectType<Skill[]>(Skill.get(['foo', 'bar']));
+expectType<Skill>(Skill.get(5));
+expectType<Skill[]>(Skill.get(['foo', 'bar', 123]));
 expectType<Skill[]>(Skill.all());
 
 expectError(Skill.get());
@@ -160,7 +166,8 @@ expectError(Stat.get(Symbol('foo')));
 expectError(Stat.get({}));
 
 expectType<Thrall>(Thrall.get('foo'));
-expectType<Thrall[]>(Thrall.get(['foo', 'bar']));
+expectType<Thrall>(Thrall.get(5));
+expectType<Thrall[]>(Thrall.get(['foo', 'bar', 123]));
 expectType<Thrall[]>(Thrall.all());
 
 expectError(Thrall.get());


### PR DESCRIPTION
The `get()` methods on enumerated classes support passing integer IDs, or an array of strings and integers. Previously, the type definitions in kolmafia-types did not support this use case. This PR addresses this.

Affected classes include: Effect, Familiar, Item, Monster, Servant, Skill, Thrall.

Also add type tests for them.