### PR TITLE
Add type definitions for some popular ASH scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added (partial) type definitions for some popular ASH scripts:
+  - CanAdv r109
+  - EatDrink 3.2
+  - PriceAdvisor 1.62
+  - ZLib r49
+
 ### Changed
 
 - Add TypeScript version requirement (>= 3.0)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,44 @@ This installs kolmafia-types under the `kolmafia` alias.
 
 ## Usage
 
+### Type definitions for ASH scripts
+
+kolmafia-types provides type definitions for some popular ASH scripts. See the `/contrib` directory for a list of available types.
+
+To use them, add an entry for each ASH script in your `tsconfig.json`:
+
+```jsonc
+{
+  "compilerOptions": {
+    // ...
+    "paths": {
+      // Note: File names are case sensitive!
+      "canadv.ash": ["./node_modules/kolmafia/contrib/canadv.ash"],
+      "zlib.ash": ["./node_modules/kolmafia/contrib/zlib.ash"]
+    }
+  }
+}
+```
+
+This allows TypeScript to type check functions imported from these ASH scripts:
+
+```ts
+// JavaScript
+const {canAdv} = require('canadv.ash');
+const {getvar, setvar} = require('zlib.ash');
+// TypeScript, Babel, or other transpilers/bundlers
+import {canAdv} from 'canadv.ash';
+import {getvar, setvar} from 'zlib.ash';
+
+setvar('my_var_1', 'some_value');
+const value = getvar('my_var_2');
+if (canAdv(Location.get('The Haunted Bedroom'), false)) {
+  // ...
+}
+```
+
+If you use a bundler, you may also need to add the ASH scripts as external modules. (See [Using a bundler](#using-a-bundler))
+
 ### Using a bundler
 
 Bundlers such as [Webpack](https://webpack.js.org/) and [Rollup](https://rollupjs.org/) can bundle all dependencies into a single file. However, `kolmafia` is a library that exists only inside KoLmafia's execution environment. Thus, you need to configure your bundler to ignore `kolmafia`.
@@ -46,6 +84,9 @@ module.exports = {
   //...
   externals: {
     kolmafia: 'commonjs kolmafia',
+    // Additional ASH scripts used in your code
+    'canadv.ash': 'commonjs canadv.ash',
+    'zlib.ash': 'commonjs zlib.ash',
   },
 };
 ```
@@ -56,6 +97,11 @@ Rollup:
 // rollup.config.js
 export default {
   // ...
-  external: ['kolmafia'],
+  external: [
+    'kolmafia',
+    // Additional ASH scripts used in your code
+    'canadv.ash',
+    'zlib.ash',
+  ],
 };
 ```

--- a/contrib/EatDrink.ash.d.ts
+++ b/contrib/EatDrink.ash.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @file Type definition for EatDrink, made by dj_d.
+ *
+ * - ASH script name: EatDrink
+ * - ASH script version: 3.2
+ * - ASH script authors: dj_d
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/eatdrink-ash-optimize-your-daily-diet-and-see-how-your-old-diet-stacks-up.1519/
+ */
+
+/**
+ * @return Net number of adventures gained
+ */
+export function eatdrink(
+  foodMax: number,
+  drinkMax: number,
+  spleenMax: number,
+  overdrink: boolean
+): number;
+
+export function eatdrink(
+  foodMax: number,
+  drinkMax: number,
+  spleenMax: number,
+  overdrink: boolean,
+  advmeat: number,
+  primemeat: number,
+  offmeat: number,
+  pullmeat: number,
+  sim: boolean
+): void;

--- a/contrib/PriceAdvisor.ash.d.ts
+++ b/contrib/PriceAdvisor.ash.d.ts
@@ -1,0 +1,41 @@
+/**
+ * @file Type definition for PriceAdvisor, made by aqualectrix.
+ *
+ * - ASH script name: PriceAdvisor
+ * - ASH script version: 1.62
+ * - ASH script authors: aqualectrix
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/priceadvisor-maximize-your-profits.3110/
+ */
+
+export interface PriceAdvice {
+  /** Action command that can be executed in the gCLI */
+  action: string;
+  /** Expected meat gain from the action. A floating-point number. */
+  price: number;
+}
+
+/**
+ * Calculates the most profitable advice for `item`.
+ * @param item
+ * @param considerMore
+ * @return Most profitable advice with respect to `considerMore`
+ */
+export function bestAdvice(it: Item, considerMore: boolean): PriceAdvice;
+
+/**
+ * Calculates all possible advices which have a positive profit.
+ * @param item
+ * @param considerMore
+ * @return All profitable advices for `item`, sorted from best to worst
+ */
+export function priceAdvisor(
+  it: Item,
+  considerMore: boolean
+): {[key: number]: PriceAdvice};
+
+/**
+ * Resets the internal price advice cache.
+ */
+export function clearAdviceCache(): void;

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,25 @@
+# README
+
+This directory provides type definitions for popular ASH scripts.
+
+## Adding a type definition
+
+If you want to submit a new type definition, ensure that the definition file name matches the spelling of the _ASH file name_. (e.g. `zlib.ash.d.ts` instead of `Zlib.ash.d.ts`)
+
+Use the following template as a starting point:
+
+```ts
+/**
+ * @file Type definition for <script name>, made by <original author name>.
+ *
+ * - ASH script name: <script name>
+ * - ASH script version: <version or revision, e.g. 2.3.0 or r42>
+ * - ASH script authors: <Comma-separated list of authors and maintainers>
+ *
+ * Links:
+ *  - ASH script forum thread: <Add URL or remove this line>
+ *  - ASH script repository: <Add URL or remove this line>
+ */
+
+// Add type definitions below and delete this comment
+```

--- a/contrib/canadv.ash.d.ts
+++ b/contrib/canadv.ash.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @file Type definition for CanAdv, made by dj_d.
+ *
+ * - ASH script name: CanAdv
+ * - ASH script version: r109
+ * - ASH script authors: zarqon, Theraze
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/canadv-check-whether-you-can-adventure-at-a-given-location.2027/
+ */
+
+/**
+ * Checks if the player can adventure at `location`.
+ * @param location
+ * @param prep If `true`, will equip items, use potions, etc. to meet
+ *    requirements for visiting the location. Default is `false`
+ */
+export function canAdv(where: Location, prep?: boolean): boolean;

--- a/contrib/zlib.ash.d.ts
+++ b/contrib/zlib.ash.d.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Type definition for Zlib, made by zarqon.
+ *
+ * - ASH script name: Zlib
+ * - ASH script version: r49
+ * - ASH script authors: zarqon
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/zlib-zarqons-useful-function-library.2072/
+ *  - Wiki page: https://wiki.kolmafia.us/index.php?title=Zlib
+ */
+
+export function kmail(to: string, message: string, meat: number): boolean;
+
+export function setvar(
+  varname: string,
+  defaultValue: string,
+  type:
+    | 'string'
+    | 'boolean'
+    | 'bounty'
+    | 'class'
+    | 'coinmaster'
+    | 'effect'
+    | 'element'
+    | 'familiar'
+    | 'float'
+    | 'int'
+    | 'item'
+    | 'location'
+    | 'monster'
+    | 'phylum'
+    | 'servant'
+    | 'skill'
+    | 'stat'
+    | 'thrall'
+    | 'vykea'
+): void;
+
+export function setvar(
+  varname: string,
+  defaultValue:
+    | string
+    | boolean
+    | Bounty
+    | Class
+    | Coinmaster
+    | Effect
+    | Element
+    | Familiar
+    | number
+    | Item
+    | Location
+    | Monster
+    | Phylum
+    | Servant
+    | Skill
+    | Stat
+    | Thrall
+    | Vykea
+): void;
+
+export function getvar(varname: string): string;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "TypeScript type declarations for KoLmafia. Alternative to kolmafia-js.",
   "types": "src/index.d.ts",
   "files": [
+    "contrib",
     "src"
   ],
   "engines": {


### PR DESCRIPTION
This PR turns kolmafia-types into a tiny analogue of  [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) for ASH scripts.

Added scripts are:

- [CanAdv](https://kolmafia.us/threads/canadv-check-whether-you-can-adventure-at-a-given-location.2027/) r109
- [EatDrink](https://kolmafia.us/threads/eatdrink-ash-optimize-your-daily-diet-and-see-how-your-old-diet-stacks-up.1519/) 3.2
- [PriceAdvisor](https://kolmafia.us/threads/priceadvisor-maximize-your-profits.3110/) 1.62
- [ZLib](https://kolmafia.us/threads/zlib-zarqons-useful-function-library.2072/) r49