### PR TITLE
feat: Add valueOf() on enumerated classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `valueOf()` on enumerated classes. (#10)
+  - The following classes return integer IDs:
+    Class, Effect, Familiar, Item, Monster, Servant, Skill, Slot, Thrall, Vykea
+  - All other classes return 0, and `valueOf()` is marked as @deprecated
+    (Bounty, Coinmaster, Element, Location, Phylum, Stat)
+
 ## [0.0.3] - 2020-01-21
 
 ### Added

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,6 +17,13 @@ declare global {
     static get(name: string): Bounty;
     static get(names: string[]): Bounty[];
     static all(): Bounty[];
+
+    /**
+     * Always returns 0, since Bounty does not have an integer ID.
+     * @deprecated
+     */
+    valueOf(): 0;
+
     /** Plural */
     readonly plural: string;
     /** Type */
@@ -37,6 +44,12 @@ declare global {
     static get(name: string): Class;
     static get(names: string[]): Class[];
     static all(): Class[];
+
+    /**
+     * Returns the integer ID of the Class.
+     */
+    valueOf(): number;
+
     /** Primestat */
     readonly primestat: Stat;
   }
@@ -45,6 +58,13 @@ declare global {
     static get(name: string): Coinmaster;
     static get(names: string[]): Coinmaster[];
     static all(): Coinmaster[];
+
+    /**
+     * Always returns 0, since Coinmaster does not have an integer ID.
+     * @deprecated
+     */
+    valueOf(): 0;
+
     /** Token */
     readonly token: string;
     /** Item */
@@ -65,6 +85,12 @@ declare global {
     static get(nameOrId: number | string): Effect;
     static get(namesAndIds: (number | string)[]): Effect[];
     static all(): Effect[];
+
+    /**
+     * Returns the integer ID of the Effect.
+     */
+    valueOf(): number;
+
     /** Name */
     readonly name: string;
     /** Default */
@@ -89,6 +115,13 @@ declare global {
     static get(name: string): Element;
     static get(names: string[]): Element[];
     static all(): Element[];
+
+    /**
+     * Always returns 0, since Element does not have an integer ID.
+     * @deprecated
+     */
+    valueOf(): 0;
+
     /** Image */
     readonly image: string;
   }
@@ -97,6 +130,12 @@ declare global {
     static get(nameOrId: number | string): Familiar;
     static get(namesAndIds: (number | string)[]): Familiar[];
     static all(): Familiar[];
+
+    /**
+     * Returns the integer ID of the Familiar.
+     */
+    valueOf(): number;
+
     /** Hatchling */
     readonly hatchling: Item;
     /** Image */
@@ -177,6 +216,12 @@ declare global {
     static get(nameOrId: number | string): Item;
     static get(namesAndIds: (number | string)[]): Item[];
     static all(): Item[];
+
+    /**
+     * Returns the integer ID of the Item.
+     */
+    valueOf(): number;
+
     /** The name of this Item. */
     readonly name: string;
     /** The name of this Item as it appears in your current Two Crazy Random Summer run. If you are not in a TCRS run, the regular Item name is returned. */
@@ -272,6 +317,13 @@ declare global {
     static get(name: string): Location;
     static get(names: string[]): Location[];
     static all(): Location[];
+
+    /**
+     * Always returns 0, since Location does not have an integer ID.
+     * @deprecated
+     */
+    valueOf(): 0;
+
     /** Nocombats */
     readonly nocombats: boolean;
     /** Combat percent */
@@ -306,6 +358,12 @@ declare global {
     static get(nameOrId: number | string): Monster;
     static get(namesAndIds: (number | string)[]): Monster[];
     static all(): Monster[];
+
+    /**
+     * Returns the integer ID of the Monster.
+     */
+    valueOf(): number;
+
     /** Name */
     readonly name: string;
     /** Id */
@@ -370,6 +428,13 @@ declare global {
     static get(name: string): Phylum;
     static get(names: string[]): Phylum[];
     static all(): Phylum[];
+
+    /**
+     * Always returns 0, since Phylum does not have an integer ID.
+     * @deprecated
+     */
+    valueOf(): 0;
+
     /** Image */
     readonly image: string;
   }
@@ -378,6 +443,12 @@ declare global {
     static get(nameOrId: number | string): Servant;
     static get(namesAndIds: (number | string)[]): Servant[];
     static all(): Servant[];
+
+    /**
+     * Returns the integer ID of the Servant.
+     */
+    valueOf(): number;
+
     /** Id */
     readonly id: number;
     /** Name */
@@ -402,6 +473,12 @@ declare global {
     static get(nameOrId: number | string): Skill;
     static get(namesAndIds: (number | string)[]): Skill[];
     static all(): Skill[];
+
+    /**
+     * Returns the integer ID of the Skill.
+     */
+    valueOf(): number;
+
     /** Name */
     readonly name: string;
     /** Type */
@@ -442,18 +519,35 @@ declare global {
     static get(name: string): Slot;
     static get(names: string[]): Slot[];
     static all(): Slot[];
+
+    /**
+     * Returns the integer ID of the Slot.
+     */
+    valueOf(): number;
   }
 
   class Stat {
     static get(name: string): Stat;
     static get(names: string[]): Stat[];
     static all(): Stat[];
+
+    /**
+     * Always returns 0, since Stat does not have an integer ID.
+     * @deprecated
+     */
+    valueOf(): 0;
   }
 
   class Thrall {
     static get(nameOrId: number | string): Thrall;
     static get(namesAndIds: (number | string)[]): Thrall[];
     static all(): Thrall[];
+
+    /**
+     * Returns the integer ID of the Thrall.
+     */
+    valueOf(): number;
+
     /** Id */
     readonly id: number;
     /** Name */
@@ -474,6 +568,14 @@ declare global {
     static get(name: string): Vykea;
     static get(names: string[]): Vykea[];
     static all(): Vykea[];
+
+    /**
+     * Returns the integer ID of the Vykea.
+     * Note that VYKEA Companions of the same type (e.g. Bookshelf) have the
+     * same ID.
+     */
+    valueOf(): number;
+
     /** Id */
     readonly id: number;
     /** Name */

--- a/test-d/global.test-d.ts
+++ b/test-d/global.test-d.ts
@@ -2,7 +2,12 @@
  * @file Type tests for global.d.ts.
  */
 
-import {expectError, expectType} from 'tsd';
+import {
+  expectDeprecated,
+  expectError,
+  expectNotDeprecated,
+  expectType,
+} from 'tsd';
 import '../src';
 
 expectType<Bounty>(Bounty.get('foo'));
@@ -16,6 +21,9 @@ expectError(Bounty.get(/regex/));
 expectError(Bounty.get(Symbol('foo')));
 expectError(Bounty.get({}));
 
+expectType<0>(Bounty.get('asdf').valueOf());
+expectDeprecated(Bounty.get('asdf').valueOf);
+
 expectType<Class>(Class.get('foo'));
 expectType<Class[]>(Class.get(['foo', 'bar']));
 expectType<Class[]>(Class.all());
@@ -27,6 +35,9 @@ expectError(Class.get(/regex/));
 expectError(Class.get(Symbol('foo')));
 expectError(Class.get({}));
 
+expectType<number>(Class.get('asdf').valueOf());
+expectNotDeprecated(Class.get('asdf').valueOf);
+
 expectType<Coinmaster>(Coinmaster.get('foo'));
 expectType<Coinmaster[]>(Coinmaster.get(['foo', 'bar']));
 expectType<Coinmaster[]>(Coinmaster.all());
@@ -37,6 +48,9 @@ expectError(Coinmaster.get(null));
 expectError(Coinmaster.get(/regex/));
 expectError(Coinmaster.get(Symbol('foo')));
 expectError(Coinmaster.get({}));
+
+expectType<0>(Coinmaster.get('asdf').valueOf());
+expectDeprecated(Coinmaster.get('asdf').valueOf);
 
 expectType<Effect>(Effect.get('foo'));
 expectType<Effect>(Effect.get(5));
@@ -50,6 +64,9 @@ expectError(Effect.get(/regex/));
 expectError(Effect.get(Symbol('foo')));
 expectError(Effect.get({}));
 
+expectType<number>(Effect.get('asdf').valueOf());
+expectNotDeprecated(Effect.get('asdf').valueOf);
+
 expectType<Element>(Element.get('foo'));
 expectType<Element[]>(Element.get(['foo', 'bar']));
 expectType<Element[]>(Element.all());
@@ -60,6 +77,9 @@ expectError(Element.get(null));
 expectError(Element.get(/regex/));
 expectError(Element.get(Symbol('foo')));
 expectError(Element.get({}));
+
+expectType<0>(Element.get('asdf').valueOf());
+expectDeprecated(Element.get('asdf').valueOf);
 
 expectType<Familiar>(Familiar.get('foo'));
 expectType<Familiar>(Familiar.get(5));
@@ -73,6 +93,9 @@ expectError(Familiar.get(/regex/));
 expectError(Familiar.get(Symbol('foo')));
 expectError(Familiar.get({}));
 
+expectType<number>(Familiar.get('asdf').valueOf());
+expectNotDeprecated(Familiar.get('asdf').valueOf);
+
 expectType<Item>(Item.get('foo'));
 expectType<Item>(Item.get(5));
 expectType<Item[]>(Item.get(['foo', 'bar', 123]));
@@ -85,6 +108,9 @@ expectError(Item.get(/regex/));
 expectError(Item.get(Symbol('foo')));
 expectError(Item.get({}));
 
+expectType<number>(Item.get('asdf').valueOf());
+expectNotDeprecated(Item.get('asdf').valueOf);
+
 expectType<Location>(Location.get('foo'));
 expectType<Location[]>(Location.get(['foo', 'bar']));
 expectType<Location[]>(Location.all());
@@ -95,6 +121,9 @@ expectError(Location.get(null));
 expectError(Location.get(/regex/));
 expectError(Location.get(Symbol('foo')));
 expectError(Location.get({}));
+
+expectType<0>(Location.get('asdf').valueOf());
+expectDeprecated(Location.get('asdf').valueOf);
 
 expectType<Monster>(Monster.get('foo'));
 expectType<Monster>(Monster.get(5));
@@ -108,6 +137,9 @@ expectError(Monster.get(/regex/));
 expectError(Monster.get(Symbol('foo')));
 expectError(Monster.get({}));
 
+expectType<number>(Monster.get('asdf').valueOf());
+expectNotDeprecated(Monster.get('asdf').valueOf);
+
 expectType<Phylum>(Phylum.get('foo'));
 expectType<Phylum[]>(Phylum.get(['foo', 'bar']));
 expectType<Phylum[]>(Phylum.all());
@@ -118,6 +150,9 @@ expectError(Phylum.get(null));
 expectError(Phylum.get(/regex/));
 expectError(Phylum.get(Symbol('foo')));
 expectError(Phylum.get({}));
+
+expectType<0>(Phylum.get('asdf').valueOf());
+expectDeprecated(Phylum.get('asdf').valueOf);
 
 expectType<Servant>(Servant.get('foo'));
 expectType<Servant>(Servant.get(5));
@@ -131,6 +166,9 @@ expectError(Servant.get(/regex/));
 expectError(Servant.get(Symbol('foo')));
 expectError(Servant.get({}));
 
+expectType<number>(Servant.get('asdf').valueOf());
+expectNotDeprecated(Servant.get('asdf').valueOf);
+
 expectType<Skill>(Skill.get('foo'));
 expectType<Skill>(Skill.get(5));
 expectType<Skill[]>(Skill.get(['foo', 'bar', 123]));
@@ -143,6 +181,9 @@ expectError(Skill.get(/regex/));
 expectError(Skill.get(Symbol('foo')));
 expectError(Skill.get({}));
 
+expectType<number>(Skill.get('asdf').valueOf());
+expectNotDeprecated(Skill.get('asdf').valueOf);
+
 expectType<Slot>(Slot.get('foo'));
 expectType<Slot[]>(Slot.get(['foo', 'bar']));
 expectType<Slot[]>(Slot.all());
@@ -154,6 +195,9 @@ expectError(Slot.get(/regex/));
 expectError(Slot.get(Symbol('foo')));
 expectError(Slot.get({}));
 
+expectType<number>(Slot.get('asdf').valueOf());
+expectNotDeprecated(Slot.get('asdf').valueOf);
+
 expectType<Stat>(Stat.get('foo'));
 expectType<Stat[]>(Stat.get(['foo', 'bar']));
 expectType<Stat[]>(Stat.all());
@@ -164,6 +208,9 @@ expectError(Stat.get(null));
 expectError(Stat.get(/regex/));
 expectError(Stat.get(Symbol('foo')));
 expectError(Stat.get({}));
+
+expectType<0>(Stat.get('asdf').valueOf());
+expectDeprecated(Stat.get('asdf').valueOf);
 
 expectType<Thrall>(Thrall.get('foo'));
 expectType<Thrall>(Thrall.get(5));
@@ -177,6 +224,9 @@ expectError(Thrall.get(/regex/));
 expectError(Thrall.get(Symbol('foo')));
 expectError(Thrall.get({}));
 
+expectType<number>(Thrall.get('asdf').valueOf());
+expectNotDeprecated(Thrall.get('asdf').valueOf);
+
 expectType<Vykea>(Vykea.get('foo'));
 expectType<Vykea[]>(Vykea.get(['foo', 'bar']));
 expectType<Vykea[]>(Vykea.all());
@@ -187,3 +237,6 @@ expectError(Vykea.get(null));
 expectError(Vykea.get(/regex/));
 expectError(Vykea.get(Symbol('foo')));
 expectError(Vykea.get({}));
+
+expectType<number>(Vykea.get('asdf').valueOf());
+expectNotDeprecated(Vykea.get('asdf').valueOf);


### PR DESCRIPTION
The following classes return integer IDs when valueOf() is called:
Class, Effect, Familiar, Item, Monster, Servant, Skill, Slot, Thrall, Vykea

For all other classes, `valueOf()` returns 0 and is marked as `@deprecated` to discourage users from calling them:
Bounty, Coinmaster, Element, Location, Phylum, Stat

Note that valueOf() is also called when the object is converted via `Number()`, as well as operators that expect primitive values (e.g. unary `+`/`-`, subtraction and multiplication).