### PR TITLE
fix: Properly type min(), max()

### DIFF
--- a/src/kolmafia.d.ts
+++ b/src/kolmafia.d.ts
@@ -389,8 +389,7 @@ export function mallPrices(category: string, tiers: string): number;
 export function manaCostModifier(): number;
 export function mapToFile(var1: unknown, var2: string): boolean;
 export function mapToFile(var1: unknown, var2: string, var3: boolean): boolean;
-export function max(arg1: number, arg2: number[]): number;
-export function max(arg1: number, arg2: number[]): number;
+export function max(arg1: number, ...args: number[]): number;
 export function maximize(
   maximizerStringValue: string,
   isSpeculateOnlyValue: boolean
@@ -419,8 +418,7 @@ export function meatDrop(): number;
 export function meatDrop(arg: Monster): number;
 export function meatDropModifier(): number;
 export function meatPockets(): {[key: number]: number};
-export function min(arg1: number, arg2: number[]): number;
-export function min(arg1: number, arg2: number[]): number;
+export function min(arg1: number, ...args: number[]): number;
 export function minstrelInstrument(): Item;
 export function minstrelLevel(): number;
 export function minstrelQuest(): boolean;

--- a/test-d/kolmafia.test-d.ts
+++ b/test-d/kolmafia.test-d.ts
@@ -2,7 +2,27 @@
  * @file Type tests for kolmafia.d.ts.
  */
 
-import {expectType} from 'tsd';
-import {isDarkMode} from '../src';
+import {expectError, expectType} from 'tsd';
+import {isDarkMode, max, min} from '../src';
 
 expectType<boolean>(isDarkMode());
+
+expectType<number>(max(0));
+expectType<number>(max(0, 1));
+expectType<number>(max(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+
+// @ts-expect-error In tsd 0.14.0, expectError() doesn't catch this error
+max();
+expectError(max('foo bar'));
+expectError(max(null));
+expectError(max(undefined));
+
+expectType<number>(min(0));
+expectType<number>(min(0, 1));
+expectType<number>(min(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+
+// @ts-expect-error In tsd 0.14.0, expectError() doesn't catch this error
+min();
+expectError(min('foo bar'));
+expectError(min(null));
+expectError(min(undefined));


### PR DESCRIPTION
`min()` and `max()` were incorrectly typed. Fix their parameters to allow variadic arguments.