### PR TITLE
fix: Remove valueOf() from enumerated classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Custom `valueOf()` methods are no longer available on enumerated types. (#13)
+
 ## [0.0.4] - 2021-01-29
 
 ### Added

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,13 +17,6 @@ declare global {
     static get(name: string): Bounty;
     static get(names: string[]): Bounty[];
     static all(): Bounty[];
-
-    /**
-     * Always returns 0, since Bounty does not have an integer ID.
-     * @deprecated
-     */
-    valueOf(): 0;
-
     /** Plural */
     readonly plural: string;
     /** Type */
@@ -44,12 +37,6 @@ declare global {
     static get(name: string): Class;
     static get(names: string[]): Class[];
     static all(): Class[];
-
-    /**
-     * Returns the integer ID of the Class.
-     */
-    valueOf(): number;
-
     /** Primestat */
     readonly primestat: Stat;
   }
@@ -58,13 +45,6 @@ declare global {
     static get(name: string): Coinmaster;
     static get(names: string[]): Coinmaster[];
     static all(): Coinmaster[];
-
-    /**
-     * Always returns 0, since Coinmaster does not have an integer ID.
-     * @deprecated
-     */
-    valueOf(): 0;
-
     /** Token */
     readonly token: string;
     /** Item */
@@ -85,12 +65,6 @@ declare global {
     static get(nameOrId: number | string): Effect;
     static get(namesAndIds: (number | string)[]): Effect[];
     static all(): Effect[];
-
-    /**
-     * Returns the integer ID of the Effect.
-     */
-    valueOf(): number;
-
     /** Name */
     readonly name: string;
     /** Default */
@@ -115,13 +89,6 @@ declare global {
     static get(name: string): Element;
     static get(names: string[]): Element[];
     static all(): Element[];
-
-    /**
-     * Always returns 0, since Element does not have an integer ID.
-     * @deprecated
-     */
-    valueOf(): 0;
-
     /** Image */
     readonly image: string;
   }
@@ -130,12 +97,6 @@ declare global {
     static get(nameOrId: number | string): Familiar;
     static get(namesAndIds: (number | string)[]): Familiar[];
     static all(): Familiar[];
-
-    /**
-     * Returns the integer ID of the Familiar.
-     */
-    valueOf(): number;
-
     /** Hatchling */
     readonly hatchling: Item;
     /** Image */
@@ -216,12 +177,6 @@ declare global {
     static get(nameOrId: number | string): Item;
     static get(namesAndIds: (number | string)[]): Item[];
     static all(): Item[];
-
-    /**
-     * Returns the integer ID of the Item.
-     */
-    valueOf(): number;
-
     /** The name of this Item. */
     readonly name: string;
     /** The name of this Item as it appears in your current Two Crazy Random Summer run. If you are not in a TCRS run, the regular Item name is returned. */
@@ -317,13 +272,6 @@ declare global {
     static get(name: string): Location;
     static get(names: string[]): Location[];
     static all(): Location[];
-
-    /**
-     * Always returns 0, since Location does not have an integer ID.
-     * @deprecated
-     */
-    valueOf(): 0;
-
     /** Nocombats */
     readonly nocombats: boolean;
     /** Combat percent */
@@ -358,12 +306,6 @@ declare global {
     static get(nameOrId: number | string): Monster;
     static get(namesAndIds: (number | string)[]): Monster[];
     static all(): Monster[];
-
-    /**
-     * Returns the integer ID of the Monster.
-     */
-    valueOf(): number;
-
     /** Name */
     readonly name: string;
     /** Id */
@@ -428,13 +370,6 @@ declare global {
     static get(name: string): Phylum;
     static get(names: string[]): Phylum[];
     static all(): Phylum[];
-
-    /**
-     * Always returns 0, since Phylum does not have an integer ID.
-     * @deprecated
-     */
-    valueOf(): 0;
-
     /** Image */
     readonly image: string;
   }
@@ -443,12 +378,6 @@ declare global {
     static get(nameOrId: number | string): Servant;
     static get(namesAndIds: (number | string)[]): Servant[];
     static all(): Servant[];
-
-    /**
-     * Returns the integer ID of the Servant.
-     */
-    valueOf(): number;
-
     /** Id */
     readonly id: number;
     /** Name */
@@ -473,12 +402,6 @@ declare global {
     static get(nameOrId: number | string): Skill;
     static get(namesAndIds: (number | string)[]): Skill[];
     static all(): Skill[];
-
-    /**
-     * Returns the integer ID of the Skill.
-     */
-    valueOf(): number;
-
     /** Name */
     readonly name: string;
     /** Type */
@@ -519,35 +442,18 @@ declare global {
     static get(name: string): Slot;
     static get(names: string[]): Slot[];
     static all(): Slot[];
-
-    /**
-     * Returns the integer ID of the Slot.
-     */
-    valueOf(): number;
   }
 
   class Stat {
     static get(name: string): Stat;
     static get(names: string[]): Stat[];
     static all(): Stat[];
-
-    /**
-     * Always returns 0, since Stat does not have an integer ID.
-     * @deprecated
-     */
-    valueOf(): 0;
   }
 
   class Thrall {
     static get(nameOrId: number | string): Thrall;
     static get(namesAndIds: (number | string)[]): Thrall[];
     static all(): Thrall[];
-
-    /**
-     * Returns the integer ID of the Thrall.
-     */
-    valueOf(): number;
-
     /** Id */
     readonly id: number;
     /** Name */
@@ -568,14 +474,6 @@ declare global {
     static get(name: string): Vykea;
     static get(names: string[]): Vykea[];
     static all(): Vykea[];
-
-    /**
-     * Returns the integer ID of the Vykea.
-     * Note that VYKEA Companions of the same type (e.g. Bookshelf) have the
-     * same ID.
-     */
-    valueOf(): number;
-
     /** Id */
     readonly id: number;
     /** Name */

--- a/test-d/global.test-d.ts
+++ b/test-d/global.test-d.ts
@@ -2,12 +2,7 @@
  * @file Type tests for global.d.ts.
  */
 
-import {
-  expectDeprecated,
-  expectError,
-  expectNotDeprecated,
-  expectType,
-} from 'tsd';
+import {expectError, expectType} from 'tsd';
 import '../src';
 
 expectType<Bounty>(Bounty.get('foo'));
@@ -21,9 +16,6 @@ expectError(Bounty.get(/regex/));
 expectError(Bounty.get(Symbol('foo')));
 expectError(Bounty.get({}));
 
-expectType<0>(Bounty.get('asdf').valueOf());
-expectDeprecated(Bounty.get('asdf').valueOf);
-
 expectType<Class>(Class.get('foo'));
 expectType<Class[]>(Class.get(['foo', 'bar']));
 expectType<Class[]>(Class.all());
@@ -35,9 +27,6 @@ expectError(Class.get(/regex/));
 expectError(Class.get(Symbol('foo')));
 expectError(Class.get({}));
 
-expectType<number>(Class.get('asdf').valueOf());
-expectNotDeprecated(Class.get('asdf').valueOf);
-
 expectType<Coinmaster>(Coinmaster.get('foo'));
 expectType<Coinmaster[]>(Coinmaster.get(['foo', 'bar']));
 expectType<Coinmaster[]>(Coinmaster.all());
@@ -48,9 +37,6 @@ expectError(Coinmaster.get(null));
 expectError(Coinmaster.get(/regex/));
 expectError(Coinmaster.get(Symbol('foo')));
 expectError(Coinmaster.get({}));
-
-expectType<0>(Coinmaster.get('asdf').valueOf());
-expectDeprecated(Coinmaster.get('asdf').valueOf);
 
 expectType<Effect>(Effect.get('foo'));
 expectType<Effect>(Effect.get(5));
@@ -64,9 +50,6 @@ expectError(Effect.get(/regex/));
 expectError(Effect.get(Symbol('foo')));
 expectError(Effect.get({}));
 
-expectType<number>(Effect.get('asdf').valueOf());
-expectNotDeprecated(Effect.get('asdf').valueOf);
-
 expectType<Element>(Element.get('foo'));
 expectType<Element[]>(Element.get(['foo', 'bar']));
 expectType<Element[]>(Element.all());
@@ -77,9 +60,6 @@ expectError(Element.get(null));
 expectError(Element.get(/regex/));
 expectError(Element.get(Symbol('foo')));
 expectError(Element.get({}));
-
-expectType<0>(Element.get('asdf').valueOf());
-expectDeprecated(Element.get('asdf').valueOf);
 
 expectType<Familiar>(Familiar.get('foo'));
 expectType<Familiar>(Familiar.get(5));
@@ -93,9 +73,6 @@ expectError(Familiar.get(/regex/));
 expectError(Familiar.get(Symbol('foo')));
 expectError(Familiar.get({}));
 
-expectType<number>(Familiar.get('asdf').valueOf());
-expectNotDeprecated(Familiar.get('asdf').valueOf);
-
 expectType<Item>(Item.get('foo'));
 expectType<Item>(Item.get(5));
 expectType<Item[]>(Item.get(['foo', 'bar', 123]));
@@ -108,9 +85,6 @@ expectError(Item.get(/regex/));
 expectError(Item.get(Symbol('foo')));
 expectError(Item.get({}));
 
-expectType<number>(Item.get('asdf').valueOf());
-expectNotDeprecated(Item.get('asdf').valueOf);
-
 expectType<Location>(Location.get('foo'));
 expectType<Location[]>(Location.get(['foo', 'bar']));
 expectType<Location[]>(Location.all());
@@ -121,9 +95,6 @@ expectError(Location.get(null));
 expectError(Location.get(/regex/));
 expectError(Location.get(Symbol('foo')));
 expectError(Location.get({}));
-
-expectType<0>(Location.get('asdf').valueOf());
-expectDeprecated(Location.get('asdf').valueOf);
 
 expectType<Monster>(Monster.get('foo'));
 expectType<Monster>(Monster.get(5));
@@ -137,9 +108,6 @@ expectError(Monster.get(/regex/));
 expectError(Monster.get(Symbol('foo')));
 expectError(Monster.get({}));
 
-expectType<number>(Monster.get('asdf').valueOf());
-expectNotDeprecated(Monster.get('asdf').valueOf);
-
 expectType<Phylum>(Phylum.get('foo'));
 expectType<Phylum[]>(Phylum.get(['foo', 'bar']));
 expectType<Phylum[]>(Phylum.all());
@@ -150,9 +118,6 @@ expectError(Phylum.get(null));
 expectError(Phylum.get(/regex/));
 expectError(Phylum.get(Symbol('foo')));
 expectError(Phylum.get({}));
-
-expectType<0>(Phylum.get('asdf').valueOf());
-expectDeprecated(Phylum.get('asdf').valueOf);
 
 expectType<Servant>(Servant.get('foo'));
 expectType<Servant>(Servant.get(5));
@@ -166,9 +131,6 @@ expectError(Servant.get(/regex/));
 expectError(Servant.get(Symbol('foo')));
 expectError(Servant.get({}));
 
-expectType<number>(Servant.get('asdf').valueOf());
-expectNotDeprecated(Servant.get('asdf').valueOf);
-
 expectType<Skill>(Skill.get('foo'));
 expectType<Skill>(Skill.get(5));
 expectType<Skill[]>(Skill.get(['foo', 'bar', 123]));
@@ -181,9 +143,6 @@ expectError(Skill.get(/regex/));
 expectError(Skill.get(Symbol('foo')));
 expectError(Skill.get({}));
 
-expectType<number>(Skill.get('asdf').valueOf());
-expectNotDeprecated(Skill.get('asdf').valueOf);
-
 expectType<Slot>(Slot.get('foo'));
 expectType<Slot[]>(Slot.get(['foo', 'bar']));
 expectType<Slot[]>(Slot.all());
@@ -195,9 +154,6 @@ expectError(Slot.get(/regex/));
 expectError(Slot.get(Symbol('foo')));
 expectError(Slot.get({}));
 
-expectType<number>(Slot.get('asdf').valueOf());
-expectNotDeprecated(Slot.get('asdf').valueOf);
-
 expectType<Stat>(Stat.get('foo'));
 expectType<Stat[]>(Stat.get(['foo', 'bar']));
 expectType<Stat[]>(Stat.all());
@@ -208,9 +164,6 @@ expectError(Stat.get(null));
 expectError(Stat.get(/regex/));
 expectError(Stat.get(Symbol('foo')));
 expectError(Stat.get({}));
-
-expectType<0>(Stat.get('asdf').valueOf());
-expectDeprecated(Stat.get('asdf').valueOf);
 
 expectType<Thrall>(Thrall.get('foo'));
 expectType<Thrall>(Thrall.get(5));
@@ -224,9 +177,6 @@ expectError(Thrall.get(/regex/));
 expectError(Thrall.get(Symbol('foo')));
 expectError(Thrall.get({}));
 
-expectType<number>(Thrall.get('asdf').valueOf());
-expectNotDeprecated(Thrall.get('asdf').valueOf);
-
 expectType<Vykea>(Vykea.get('foo'));
 expectType<Vykea[]>(Vykea.get(['foo', 'bar']));
 expectType<Vykea[]>(Vykea.all());
@@ -237,6 +187,3 @@ expectError(Vykea.get(null));
 expectError(Vykea.get(/regex/));
 expectError(Vykea.get(Symbol('foo')));
 expectError(Vykea.get({}));
-
-expectType<number>(Vykea.get('asdf').valueOf());
-expectNotDeprecated(Vykea.get('asdf').valueOf);


### PR DESCRIPTION
This reverts #10 (specifically commit 21f8c53fa38b9450b9380755eca0c5c291ffae32).

Enumerated types in KoLmafia previously used a custom `valueOf()` implementation while still enjoying the benefits of string concatenation. Unfortunately, [this was unintentionally exploiting a bug in the Rhino engine.](https://kolmafia.us/threads/javascript-remove-custom-valueof-implementation-for-enumerated-types.25844/) Not only was this behavior not reproducible in other JS runtimes, but it could be fixed in a future release of Rhino, which would break all JS scripts that relied on the buggy behavior. To prevent this early, KoLmafia dropped the custom `valueOf()` implementation in [r20620](https://kolmafia.us/threads/20620-remove-valueof-as-per-philmasterplus.25845/). We therefore remove the types for `valueOf()` as well.