### PR TITLE
feat: Add license statement for kolmafia-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `canEquip(fam: Familiar)` form (#15)
 
+### Fixed
+
+- Properly specify the license of [kolmafia-js], which this project derives
+  from.(#16)
+
 ## [0.0.6] - 2021-02-20
 
 ### Added

--- a/src/kolmafia.d.ts
+++ b/src/kolmafia.d.ts
@@ -6,8 +6,29 @@ import './global';
 
 // These type definitions are derived from kolmafia-js v1.0.4, written by Samuel
 // Gaus (@gausie). kolmafia-js provides type definitions generated from
-// KoLmafia's source code. Because kolmafia-js does not come with a license as
-// of writing, I post none here.
+// KoLmafia's source code. kolmafia-js is released under the MIT license:
+
+/*
+Copyright (c) 2020 Samuel Gaus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
 
 /**
  * Immediately halts the current script and all queued functions.


### PR DESCRIPTION
It turns out [kolmafia-js]( https://github.com/Loathing-Associates-Scripting-Society/kolmafiajs/) is released under the MIT license all along!

See: https://github.com/Loathing-Associates-Scripting-Society/kolmafia-js/blob/44a2a735bc8b0e41b457d5874304a2a8afa57883/package.json#L8

To properly credit @gausie's work, let's add the license statement inside `kolmafia.d.ts`.