### PR TITLE
Extract modifier/Cargo Cultist Shorts-related functions to separate modules

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,3 @@
 import './global';
 export * from './kolmafia';
+export * from './kolmafia-modifier';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
 import './global';
 export * from './kolmafia';
+export * from './kolmafia-cargo-cultist-shorts';
 export * from './kolmafia-modifier';

--- a/src/kolmafia-cargo-cultist-shorts.d.ts
+++ b/src/kolmafia-cargo-cultist-shorts.d.ts
@@ -1,0 +1,76 @@
+/**
+ * @file KoLmafia functions for managing the pockets of Cargo Cultist Shorts.
+ */
+
+import './global';
+
+/**
+ * Returns an unopened pocket number in your Cargo Cultist Shorts that will
+ * result in a fight with the `monster`.
+ * @param monster Monster to search for
+ * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
+ *    available pockets contain the `monster`
+ */
+export function availablePocket(monster: Monster): number;
+
+/**
+ * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
+ * the most turns of `effect`.
+ * @param effect Effect to search for
+ * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
+ *    available pockets contain the `effect`
+ */
+export function availablePocket(effect: Effect): number;
+
+/**
+ * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
+ * the largest number of `item`.
+ * @param item Item to look for
+ * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
+ *    available pockets contain the `item`
+ */
+export function availablePocket(item: Item): number;
+
+/**
+ * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
+ * the most substats for the `stat`.
+ * @param stat Stat to look for
+ * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
+ *    available pockets give the `stat`
+ */
+export function availablePocket(stat: Stat): number;
+
+export function effectPockets(): {[key: number]: boolean};
+export function itemPockets(): {[key: number]: boolean};
+export function jokePockets(): {[key: number]: boolean};
+export function meatPockets(): {[key: number]: number};
+export function monsterPockets(): {[key: number]: boolean};
+
+export function pickPocket(arg: number): boolean;
+export function pickPocket(arg: Monster): boolean;
+export function pickPocket(arg: Effect): {[effect: string]: number};
+export function pickPocket(arg: Item): {[item: string]: number};
+export function pickPocket(arg: Stat): {[stat: string]: number};
+
+export function pickedPockets(): {[key: number]: boolean};
+export function pickedScraps(): {[key: number]: boolean};
+
+export function pocketEffects(pocket: number): {[effect: string]: number};
+export function pocketItems(pocket: number): {[item: string]: number};
+export function pocketJoke(pocket: number): string;
+export function pocketMeat(pocket: number): {[key: number]: string};
+export function pocketMonster(pocket: number): Monster;
+export function pocketPoem(pocket: number): {[key: number]: string};
+export function pocketScrap(pocket: number): {[key: number]: string};
+export function pocketStats(pocket: number): {[stat: string]: number};
+
+export function poemPockets(): {[key: number]: number};
+
+export function potentialPockets(arg: Monster): {[key: number]: number};
+export function potentialPockets(arg: Effect): {[key: number]: number};
+export function potentialPockets(arg: Item): {[key: number]: number};
+export function potentialPockets(arg: Stat): {[key: number]: number};
+
+export function restorationPockets(): {[key: number]: boolean};
+export function scrapPockets(): {[key: number]: number};
+export function statsPockets(): {[key: number]: boolean};

--- a/src/kolmafia-modifier.d.ts
+++ b/src/kolmafia-modifier.d.ts
@@ -1,0 +1,95 @@
+/**
+ * @file KoLmafia functions that interact with modifiers.
+ */
+
+import './global';
+
+/**
+ * Accesses fields of your current modifiers for all of your current equipment
+ * and effects. This uses the same mechanism that lets KoLmafia decide whether
+ * you can adventure underwater, or how many songs you can keep in your head.
+ * @param modifier Modifier name
+ * @return Modifier value
+ */
+export function booleanModifier(modifier: string): boolean;
+
+/**
+ * Extracts a modifier from `source` and parses it as a boolean value.
+ *
+ * The modifier string can be any of the following:
+ *
+ * - Item name, e.g. `"pail"`
+ * - Item ID (integer) surrounded by brackets, e.g. `"[123]"`
+ * - String of the form `<type>:<name>`, where...
+ *   - `<type>` is a modifier source type, e.g. `Item`, `Effect`, `Skill`
+ *   - `<name>` is the name of the item/effect/skill/etc.
+ * @param source Modifier source string
+ * @param modifier Modifier name
+ * @return Modifier value
+ */
+export function booleanModifier(source: string, modifier: string): boolean;
+
+/**
+ * Accesses a boolean modifier provided by the `item`.
+ * @param item Item to check
+ * @param modifier Modifier name
+ * @return Modifier value
+ */
+export function booleanModifier(item: Item, modifier: string): boolean;
+
+/**
+ * Accesses a boolean modifier provided by the `effect`.
+ * @param effect Effect to check
+ * @param modifier Modifier name
+ * @return Modifier value
+ */
+export function booleanModifier(effect: Effect, modifier: string): boolean;
+
+/**
+ * Extracts a modifier from `source` and parses it as a `Class` object.
+ *
+ * The modifier string can be any of the following:
+ *
+ * - Item name, e.g. `"pail"`
+ * - Item ID (integer) surrounded by brackets, e.g. `"[123]"`
+ * - String of the form `<type>:<name>`, where...
+ *   - `<type>` is a modifier source type, e.g. `Item`, `Effect`, `Skill`
+ *   - `<name>` is the name of the item/effect/skill/etc.
+ * @param source Modifier source string
+ * @param modifier Modifier name to parse, typically `"Class"`
+ * @return Value of the modifier, parsed as a `Class`
+ */
+export function classModifier(source: string, modifier: string): Class;
+
+/**
+ * Extracts a modifier on an `item` and parses it as a `Class` object.
+ * By passing `"Class"` as the modifier name, this function can be used to
+ * retrieve the character class of a class-specific item.
+ * @param item Item to check
+ * @param modifier Modifier name to parse, typically `"Class"`
+ * @return Value of the modifier, parsed as a `Class`
+ */
+export function classModifier(item: Item, modifier: string): Class;
+
+export function effectModifier(arg: string, modifier: string): Effect;
+export function effectModifier(arg: Item, modifier: string): Effect;
+
+export function numericModifier(modifier: string): number;
+export function numericModifier(arg: string, modifier: string): number;
+export function numericModifier(arg: Item, modifier: string): number;
+export function numericModifier(arg: Effect, modifier: string): number;
+export function numericModifier(arg: Skill, modifier: string): number;
+export function numericModifier(
+  familiar: Familiar,
+  modifier: string,
+  weight: number,
+  item: Item
+): number;
+
+export function skillModifier(arg: string, modifier: string): Skill;
+export function skillModifier(arg: Item, modifier: string): Skill;
+
+export function statModifier(arg: Effect, modifier: string): Stat;
+
+export function stringModifier(modifier: string): string;
+export function stringModifier(arg: string, modifier: string): string;

--- a/src/kolmafia.d.ts
+++ b/src/kolmafia.d.ts
@@ -1,5 +1,8 @@
 /**
  * @file Type definitions for KoLmafia's standard (runtime) library.
+ *
+ * Note: This module contains uncategorized library functions.
+ * See modules named `kolmafia-*.d.ts` for categorized functions.
  */
 
 import './global';
@@ -432,47 +435,6 @@ export function bjornifyFamiliar(familiar: Familiar): boolean;
 export function blackMarketAvailable(): boolean;
 
 /**
- * Accesses fields of your current modifiers for all of your current equipment
- * and effects. This uses the same mechanism that lets KoLmafia decide whether
- * you can adventure underwater, or how many songs you can keep in your head.
- * @param modifier Modifier name
- * @return Modifier value
- */
-export function booleanModifier(modifier: string): boolean;
-
-/**
- * Extracts a modifier from `source` and parses it as a boolean value.
- *
- * The modifier string can be any of the following:
- *
- * - Item name, e.g. `"pail"`
- * - Item ID (integer) surrounded by brackets, e.g. `"[123]"`
- * - String of the form `<type>:<name>`, where...
- *   - `<type>` is a modifier source type, e.g. `Item`, `Effect`, `Skill`
- *   - `<name>` is the name of the item/effect/skill/etc.
- * @param source Modifier source string
- * @param modifier Modifier name
- * @return Modifier value
- */
-export function booleanModifier(source: string, modifier: string): boolean;
-
-/**
- * Accesses a boolean modifier provided by the `item`.
- * @param item Item to check
- * @param modifier Modifier name
- * @return Modifier value
- */
-export function booleanModifier(item: Item, modifier: string): boolean;
-
-/**
- * Accesses a boolean modifier provided by the `effect`.
- * @param effect Effect to check
- * @param modifier Modifier name
- * @return Modifier value
- */
-export function booleanModifier(effect: Effect, modifier: string): boolean;
-
-/**
  * Returns the buffed value of the stat used to calculate your hit chance.
  *
  * Note: Melee weapons use muscle to calculate hit change, and ranged weapons
@@ -820,32 +782,6 @@ export function chew(qty: number, item: Item): boolean;
 export function choiceFollowsFight(): boolean;
 
 /**
- * Extracts a modifier from `source` and parses it as a `Class` object.
- *
- * The modifier string can be any of the following:
- *
- * - Item name, e.g. `"pail"`
- * - Item ID (integer) surrounded by brackets, e.g. `"[123]"`
- * - String of the form `<type>:<name>`, where...
- *   - `<type>` is a modifier source type, e.g. `Item`, `Effect`, `Skill`
- *   - `<name>` is the name of the item/effect/skill/etc.
- * @param source Modifier source string
- * @param modifier Modifier name to parse, typically `"Class"`
- * @return Value of the modifier, parsed as a `Class`
- */
-export function classModifier(source: string, modifier: string): Class;
-
-/**
- * Extracts a modifier on an `item` and parses it as a `Class` object.
- * By passing `"Class"` as the modifier name, this function can be used to
- * retrieve the character class of a class-specific item.
- * @param item Item to check
- * @param modifier Modifier name to parse, typically `"Class"`
- * @return Value of the modifier, parsed as a `Class`
- */
-export function classModifier(item: Item, modifier: string): Class;
-
-/**
  * Empties the given aggregate (map).
  *
  * **NOTE: Because the internal library function actually "clears" a copy of the
@@ -1149,8 +1085,6 @@ export function eat(arg1: number, arg2: Item): boolean;
 export function eatsilent(item: Item): boolean;
 export function eatsilent(arg1: Item, arg2: number): boolean;
 export function eatsilent(arg1: number, arg2: Item): boolean;
-export function effectModifier(arg: string, modifier: string): Effect;
-export function effectModifier(arg: Item, modifier: string): Effect;
 export function effectPockets(): {[key: number]: boolean};
 export function elementalResistance(arg: Element): number;
 export function elementalResistance(): number;
@@ -1507,17 +1441,6 @@ export function nowToInt(): number;
 export function nowToString(dateFormatValue: string): string;
 export function npcPrice(item: Item): number;
 export function numberologyPrize(num: number): string;
-export function numericModifier(modifier: string): number;
-export function numericModifier(arg: string, modifier: string): number;
-export function numericModifier(arg: Item, modifier: string): number;
-export function numericModifier(arg: Effect, modifier: string): number;
-export function numericModifier(arg: Skill, modifier: string): number;
-export function numericModifier(
-  familiar: Familiar,
-  modifier: string,
-  weight: number,
-  item: Item
-): number;
 export function outfit(outfit: string): boolean;
 export function outfitPieces(outfit: string): Item[];
 export function outfitTattoo(outfit: string): string;
@@ -1673,8 +1596,6 @@ export function setProperty(nameValue: string, value: string): void;
 export function shopAmount(arg: Item): number;
 export function shopLimit(arg: Item): number;
 export function shopPrice(item: Item): number;
-export function skillModifier(arg: string, modifier: string): Skill;
-export function skillModifier(arg: Item, modifier: string): Skill;
 export function slashCount(arg: Item): number;
 export function soulsauceCost(skill: Skill): number;
 export function spleenLimit(): number;
@@ -1685,14 +1606,11 @@ export function startsWith(source: string, prefix: string): boolean;
 export function stashAmount(arg: Item): number;
 export function statBonusToday(): Stat;
 export function statBonusTomorrow(): Stat;
-export function statModifier(arg: Effect, modifier: string): Stat;
 export function statsPockets(): {[key: number]: boolean};
 export function steal(): string;
 export function stillsAvailable(): number;
 export function stopCounter(label: string): void;
 export function storageAmount(arg: Item): number;
-export function stringModifier(modifier: string): string;
-export function stringModifier(arg: string, modifier: string): string;
 export function stunSkill(): Skill;
 export function substring(source: string, start: number): string;
 export function substring(

--- a/src/kolmafia.d.ts
+++ b/src/kolmafia.d.ts
@@ -359,42 +359,6 @@ export function availableChoiceTextInputs(
 ): {[inputName: string]: ''};
 
 /**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will
- * result in a fight with the `monster`.
- * @param monster Monster to search for
- * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
- *    available pockets contain the `monster`
- */
-export function availablePocket(monster: Monster): number;
-
-/**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
- * the most turns of `effect`.
- * @param effect Effect to search for
- * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
- *    available pockets contain the `effect`
- */
-export function availablePocket(effect: Effect): number;
-
-/**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
- * the largest number of `item`.
- * @param item Item to look for
- * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
- *    available pockets contain the `item`
- */
-export function availablePocket(item: Item): number;
-
-/**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
- * the most substats for the `stat`.
- * @param stat Stat to look for
- * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
- *    available pockets give the `stat`
- */
-export function availablePocket(stat: Stat): number;
-
-/**
  * Exits batch mode, executes all batch-aware operations that were called after
  * the last `batchOpen()`. This reduces the number of server hits.
  *
@@ -1085,7 +1049,6 @@ export function eat(arg1: number, arg2: Item): boolean;
 export function eatsilent(item: Item): boolean;
 export function eatsilent(arg1: Item, arg2: number): boolean;
 export function eatsilent(arg1: number, arg2: Item): boolean;
-export function effectPockets(): {[key: number]: boolean};
 export function elementalResistance(arg: Element): number;
 export function elementalResistance(): number;
 export function elementalResistance(arg: Monster): number;
@@ -1266,9 +1229,7 @@ export function itemDropsArray(
 export function itemDropsArray(
   arg: Monster
 ): {drop: Item; rate: number; type: string}[];
-export function itemPockets(): {[key: number]: boolean};
 export function itemType(item: Item): string;
-export function jokePockets(): {[key: number]: boolean};
 export function jumpChance(): number;
 export function jumpChance(arg: Monster): number;
 export function jumpChance(arg: Monster, init: number): number;
@@ -1338,7 +1299,6 @@ export function maximize(
 export function meatDrop(): number;
 export function meatDrop(arg: Monster): number;
 export function meatDropModifier(): number;
-export function meatPockets(): {[key: number]: number};
 
 /**
  * Returns the smallest number among the given arguments.
@@ -1365,7 +1325,6 @@ export function monsterLevelAdjustment(): number;
 export function monsterManuelText(arg: Monster): string;
 export function monsterPhylum(): Phylum;
 export function monsterPhylum(arg: Monster): Phylum;
-export function monsterPockets(): {[key: number]: boolean};
 export function moodExecute(multiplicity: number): void;
 export function moodList(): string[];
 export function moonLight(): number;
@@ -1449,26 +1408,6 @@ export function overdrink(arg1: Item, arg2: number): boolean;
 export function overdrink(arg1: number, arg2: Item): boolean;
 export function pathIdToName(value: number): string;
 export function pathNameToId(value: string): number;
-export function pickPocket(arg: number): boolean;
-export function pickPocket(arg: Monster): boolean;
-export function pickPocket(arg: Effect): {[effect: string]: number};
-export function pickPocket(arg: Item): {[item: string]: number};
-export function pickPocket(arg: Stat): {[stat: string]: number};
-export function pickedPockets(): {[key: number]: boolean};
-export function pickedScraps(): {[key: number]: boolean};
-export function pocketEffects(pocket: number): {[effect: string]: number};
-export function pocketItems(pocket: number): {[item: string]: number};
-export function pocketJoke(pocket: number): string;
-export function pocketMeat(pocket: number): {[key: number]: string};
-export function pocketMonster(pocket: number): Monster;
-export function pocketPoem(pocket: number): {[key: number]: string};
-export function pocketScrap(pocket: number): {[key: number]: string};
-export function pocketStats(pocket: number): {[stat: string]: number};
-export function poemPockets(): {[key: number]: number};
-export function potentialPockets(arg: Monster): {[key: number]: number};
-export function potentialPockets(arg: Effect): {[key: number]: number};
-export function potentialPockets(arg: Item): {[key: number]: number};
-export function potentialPockets(arg: Stat): {[key: number]: number};
 export function print(): void;
 export function print(string: string): void;
 export function print(string: string, color: string): void;
@@ -1548,7 +1487,6 @@ export function repriceShop(
   limitValue: number,
   itemValue: Item
 ): boolean;
-export function restorationPockets(): {[key: number]: boolean};
 export function restoreHp(amount: number): boolean;
 export function restoreMp(amount: number): boolean;
 export function retrieveItem(item: Item): boolean;
@@ -1573,7 +1511,6 @@ export function runCombat(): string;
 export function runCombat(filterFunction: string): string;
 export function runTurn(): string;
 export function runaway(): string;
-export function scrapPockets(): {[key: number]: number};
 export function sell(
   master: Coinmaster,
   countValue: number,
@@ -1606,7 +1543,6 @@ export function startsWith(source: string, prefix: string): boolean;
 export function stashAmount(arg: Item): number;
 export function statBonusToday(): Stat;
 export function statBonusTomorrow(): Stat;
-export function statsPockets(): {[key: number]: boolean};
 export function steal(): string;
 export function stillsAvailable(): number;
 export function stopCounter(label: string): void;

--- a/test-d/kolmafia-modifier.test-d.ts
+++ b/test-d/kolmafia-modifier.test-d.ts
@@ -1,0 +1,47 @@
+/**
+ * @file Type tests for modifier-related functions.
+ */
+
+import {expectType} from 'tsd';
+import {
+  booleanModifier,
+  classModifier,
+  effectModifier,
+  numericModifier,
+  skillModifier,
+  statModifier,
+  stringModifier,
+} from '../src';
+
+expectType<boolean>(booleanModifier('foo'));
+expectType<boolean>(booleanModifier('foo', 'bar'));
+expectType<boolean>(booleanModifier(Item.get('foo'), 'bar'));
+expectType<boolean>(booleanModifier(Effect.get('foo'), 'bar'));
+
+expectType<boolean>(booleanModifier('foo'));
+expectType<boolean>(booleanModifier('foo', 'bar'));
+expectType<boolean>(booleanModifier(Item.get('foo'), 'bar'));
+expectType<boolean>(booleanModifier(Effect.get('foo'), 'bar'));
+
+expectType<Class>(classModifier('foo', 'bar'));
+expectType<Class>(classModifier(Item.get('foo'), 'bar'));
+
+expectType<Effect>(effectModifier('foo', 'bar'));
+expectType<Effect>(effectModifier(Item.get('foo'), 'bar'));
+
+expectType<number>(numericModifier('foo'));
+expectType<number>(numericModifier('foo', 'bar'));
+expectType<number>(numericModifier(Item.get('foo'), 'bar'));
+expectType<number>(numericModifier(Effect.get('foo'), 'bar'));
+expectType<number>(numericModifier(Skill.get('foo'), 'bar'));
+expectType<number>(
+  numericModifier(Familiar.get('foo'), 'bar', 10, Item.get('baz'))
+);
+
+expectType<Skill>(skillModifier('foo', 'bar'));
+expectType<Skill>(skillModifier(Item.get('foo'), 'bar'));
+
+expectType<Stat>(statModifier(Effect.get('foo'), 'bar'));
+
+expectType<string>(stringModifier('foo'));
+expectType<string>(stringModifier('foo', 'bar'));


### PR DESCRIPTION
Several KoLmafia functions are closely related to each other. They are either designed around a specific functionality, are backed by the same subsystem, or share common behavior. For example, all modifier-retrieving functions reflect the underlying design of KoLmafia's modifier system. Because of this, it makes sense to group and maintain their documentation together.

To facilitate this, I'm planning to categorize and split off groups of functions into separate modules. `kolmafia.d.ts` shall remain as the pool of uncategorized functions.

This PR splits off:

- `kolmafia-cargo-cultist-shorts.d.ts`: Functions that access and manipulate pockets in the [Cargo Cultist Shorts](https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts)
- `kolmafia-modifier.d.ts`: Functions that retrieve modifiers

Note that these distinctions are mostly arbitrary. It would be difficult to define a formal system for classifying functions. For now, I'll have to rely on intuition.

This PR also adds type tests for the modifier-retrieving functions.