### PR TITLE
feat!: Require TypeScript 4.1 (and add custom test script)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `canEquip(fam: Familiar)` form ([#15])
 - Detailed comments for library functions that start with D up to E. ([#19])
 
+### Changed
+
+- Now requires TypeScript 4.1+ ([#20])
+
 ### Fixed
 
 - Properly specify the license of [kolmafia-js], which this project derives
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#16]: https://github.com/pastelmind/kolmafia-types/pull/16
 [#17]: https://github.com/pastelmind/kolmafia-types/pull/17
 [#19]: https://github.com/pastelmind/kolmafia-types/pull/19
+[#20]: https://github.com/pastelmind/kolmafia-types/pull/20
 
 ## [0.0.6] - 2021-02-20
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ visitUrl(123); // Type error
 
 ## Installation
 
-kolmafia-types requires TypeScript 3.0 or above.
+**kolmafia-types requires TypeScript 4.1 or above.** If your TypeScript version
+is lower than this, you may see compiler error messages like
+"Cannot find module 'kolmafia-types'."
 
 To use kolmafia-types in your project, you can choose one of:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,12 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
     },
+    "@types/node": {
+      "version": "12.20.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
+      "dev": true
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -362,6 +368,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -441,6 +453,12 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -584,6 +602,12 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -659,6 +683,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "dir-glob": {
@@ -1349,7 +1379,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "inquirer": {
       "version": "7.3.3",
@@ -1631,6 +1662,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "map-obj": {
       "version": "4.1.0",
@@ -2257,6 +2294,22 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -2434,6 +2487,20 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
       "dev": true
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
     },
     "tsd": {
       "version": "0.14.0",
@@ -2715,6 +2782,12 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "src"
   ],
   "engines": {
+    "node": ">= 11.14 || ^10.17",
     "npm": ">= 6.9.0",
     "yarn": ">= 0.17.0"
   },
   "scripts": {
     "lint": "gts lint",
     "fix": "gts fix",
-    "test": "tsd",
+    "test": "ts-node run-tests.ts",
     "posttest": "npm run lint"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "kolmafia-types",
   "version": "0.0.6",
   "description": "TypeScript type declarations for KoLmafia. Alternative to kolmafia-js.",
-  "types": "src/index.d.ts",
+  "typesVersions": {
+    ">=4.1": {
+      "*": [
+        "src/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "contrib",
     "src"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   },
   "homepage": "https://github.com/pastelmind/kolmafia-types#readme",
   "devDependencies": {
+    "@types/node": "^12.20.7",
     "gts": "^3.1.0",
+    "ts-node": "^9.1.1",
     "tsd": "^0.14.0",
     "typescript": "^4.1.3"
   }

--- a/run-tests.ts
+++ b/run-tests.ts
@@ -1,0 +1,40 @@
+import {promises} from 'fs';
+import tsd from 'tsd';
+import formatter from 'tsd/dist/lib/formatter';
+
+const {readFile, writeFile} = promises;
+
+const PACKAGE_JSON = './package.json';
+
+async function main() {
+  // tsd 0.14.0 does not support typesVersions key, despite being powered by
+  // TypeScript 4.1
+  // Thus, we must temporarily modify package.json
+  const pkgText = await readFile(PACKAGE_JSON, 'utf8');
+  const pkg: typeof import('./package.json') = JSON.parse(pkgText);
+
+  const tempPkg = {
+    ...pkg,
+    types: Object.values(Object.values(pkg.typesVersions)[0])[0][0],
+  };
+  await writeFile(PACKAGE_JSON, JSON.stringify(tempPkg));
+
+  try {
+    const diagnostics = await tsd();
+    if (diagnostics.length > 0) {
+      throw new Error(formatter(diagnostics));
+    }
+  } finally {
+    // Restore previous package.json
+    await writeFile(PACKAGE_JSON, pkgText);
+  }
+}
+
+(async () => {
+  try {
+    await main();
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  }
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/gts/tsconfig-google.json"
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }


### PR DESCRIPTION
The type definition for `eudora(newEudora)` added in #19 uses `Lowercase<T>`, which was added in TypeScript 4.1. Because of this, we now require TypeScript 4.1+ by using the `typesVersions` field in `package.json` instead of a `types` field.

[TypeScript 4.1 was released in November 2020.](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/) Hopefully, enough time has passed that asking users to adopt TS 4.1+ is not a big problem--and if it is, time would solve it quickly.

We use the `typesVersions` field in `package.json` to control version requirements. This field is [supported in TypeScript 3.1+](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions). Since TS 3.1 was released in October 2018, it's unlikely that any users of kolmafia-types may have an older version. (Notably, [DefinitelyTyped no longer supports TS 3.1 as of 2021](https://github.com/DefinitelyTyped/DefinitelyTyped#older-versions-of-typescript-34-and-earlier).) Thus, we probably don't need to worry about TypeScript versions < 3.1.

---

[tsd](https://github.com/SamVerschueren/tsd) (our testing tool) currently does not support `typesVersions` and does not provide any mechanism for specifying a custom type source. It simply needs the `types` field in `package.json`.

To work around this, I wrote a tiny Node.js script (`run-tests.ts`) that monkey-patches `package.json` with a `types` field before running `tsd`, then restore the original afterwards. I also installed `ts-node` to avoid an extra compile step when running the script.

Note: The `main` branch of tsd has recently gained [support for custom type sources.](https://github.com/SamVerschueren/tsd/pull/74)  [Another PR adds an accompanying CLI option for this](https://github.com/SamVerschueren/tsd/pull/93). If the next release of tsd includes these changes, we may be able to replace this script with an invocation of `tsd --typings-file src/index.d.ts`.