### PR TITLE
Mark constructors of built-in classes as private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ List of sections:
 
 ## [Unreleased]
 
+### Changed
+
+- Built-in classes can no longer be instanted directly; their constructors have
+  been marked as private. ([#23])
+
+[#23]: https://github.com/pastelmind/kolmafia-types/pull/23
+
 ## [0.1.0] - 2021-04-05
 
 ### Added

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -34,7 +34,15 @@ SOFTWARE.
  */
 
 declare global {
+  // KoLmafia built-in classes cannot be instanted; KoLmafia will abort the
+  // JavaScript runtime.
+  // As such, all constructors have been made private to prevent users from
+  // attempting to instantiate them. This still allows the classes to be used in
+  // `instanceof` checks.
+
   class Bounty {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Bounty;
     static get(names: string[]): Bounty[];
     static all(): Bounty[];
@@ -55,6 +63,8 @@ declare global {
   }
 
   class Class {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Class;
     static get(names: string[]): Class[];
     static all(): Class[];
@@ -63,6 +73,8 @@ declare global {
   }
 
   class Coinmaster {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Coinmaster;
     static get(names: string[]): Coinmaster[];
     static all(): Coinmaster[];
@@ -83,6 +95,8 @@ declare global {
   }
 
   class Effect {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Effect;
     static get(namesAndIds: (number | string)[]): Effect[];
     static all(): Effect[];
@@ -107,6 +121,8 @@ declare global {
   }
 
   class Element {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Element;
     static get(names: string[]): Element[];
     static all(): Element[];
@@ -115,6 +131,8 @@ declare global {
   }
 
   class Familiar {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Familiar;
     static get(namesAndIds: (number | string)[]): Familiar[];
     static all(): Familiar[];
@@ -195,6 +213,8 @@ declare global {
   }
 
   class Item {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Item;
     static get(namesAndIds: (number | string)[]): Item[];
     static all(): Item[];
@@ -300,6 +320,8 @@ declare global {
   }
 
   class Location {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Location;
     static get(names: string[]): Location[];
     static all(): Location[];
@@ -334,6 +356,8 @@ declare global {
   }
 
   class Monster {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Monster;
     static get(namesAndIds: (number | string)[]): Monster[];
     static all(): Monster[];
@@ -398,6 +422,8 @@ declare global {
   }
 
   class Phylum {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Phylum;
     static get(names: string[]): Phylum[];
     static all(): Phylum[];
@@ -406,6 +432,8 @@ declare global {
   }
 
   class Servant {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Servant;
     static get(namesAndIds: (number | string)[]): Servant[];
     static all(): Servant[];
@@ -430,6 +458,8 @@ declare global {
   }
 
   class Skill {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Skill;
     static get(namesAndIds: (number | string)[]): Skill[];
     static all(): Skill[];
@@ -470,18 +500,24 @@ declare global {
   }
 
   class Slot {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Slot;
     static get(names: string[]): Slot[];
     static all(): Slot[];
   }
 
   class Stat {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Stat;
     static get(names: string[]): Stat[];
     static all(): Stat[];
   }
 
   class Thrall {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(nameOrId: number | string): Thrall;
     static get(namesAndIds: (number | string)[]): Thrall[];
     static all(): Thrall[];
@@ -502,6 +538,8 @@ declare global {
   }
 
   class Vykea {
+    /** KoLmafia built-in classes cannot be instantiated directly. */
+    private constructor();
     static get(name: string): Vykea;
     static get(names: string[]): Vykea[];
     static all(): Vykea[];

--- a/test-d/global.test-d.ts
+++ b/test-d/global.test-d.ts
@@ -2,7 +2,7 @@
  * @file Type tests for global.d.ts.
  */
 
-import {expectError, expectType} from 'tsd';
+import {expectError, expectNotAssignable, expectType} from 'tsd';
 import '../src';
 
 expectType<Bounty>(Bounty.get('foo'));
@@ -187,3 +187,59 @@ expectError(Vykea.get(null));
 expectError(Vykea.get(/regex/));
 expectError(Vykea.get(Symbol('foo')));
 expectError(Vykea.get({}));
+
+// Forbid using KoLmafia built-in classes as regular functions
+
+expectNotAssignable<CallableFunction>(Bounty);
+expectNotAssignable<CallableFunction>(Class);
+expectNotAssignable<CallableFunction>(Coinmaster);
+expectNotAssignable<CallableFunction>(Effect);
+expectNotAssignable<CallableFunction>(Element);
+expectNotAssignable<CallableFunction>(Familiar);
+expectNotAssignable<CallableFunction>(Item);
+expectNotAssignable<CallableFunction>(Location);
+expectNotAssignable<CallableFunction>(Monster);
+expectNotAssignable<CallableFunction>(Phylum);
+expectNotAssignable<CallableFunction>(Servant);
+expectNotAssignable<CallableFunction>(Skill);
+expectNotAssignable<CallableFunction>(Slot);
+expectNotAssignable<CallableFunction>(Stat);
+expectNotAssignable<CallableFunction>(Thrall);
+expectNotAssignable<CallableFunction>(Vykea);
+
+// Forbid directly instantiating KoLmafia built-in classes
+// Note: tsd cannot check if the constructor is private,
+// so we need to use @ts-expect-error.
+
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Bounty();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Class();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Coinmaster();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Effect();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Element();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Familiar();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Item();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Location();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Monster();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Phylum();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Servant();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Skill();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Slot();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Stat();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Thrall();
+// @ts-expect-error KoLmafia built-ins cannot be directly instantiated
+new Vykea();


### PR DESCRIPTION
KoLmafia built-in classes (`Item`, `Effect`, ...) cannot be instantiated directly (e.g. `let item = new Item()`); doing so causes KoLmafia's JavaScript runtime to abort. As such, let's mark their constructors as private to prevent users from attempting to instantiate them directly.

This commit also adds test cases that verify whether it is a type error to:

1. Instantiate the class directly
2. Call the constructor as a function

---

Note: One alternative approach to forbidding instantiation is to replace each class with a pair of interface and a namespace. The interface would define the instance properties, and the namespace would define the static properties.
However, this approach would prevent us from using `instanceof` checks with the builtins, which is why I chose the current approach.