### PR TITLE
feat: Add type definitions for require() and module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,17 @@ List of sections:
 
 ## [Unreleased]
 
+### Added
+
+- Type definitions for CommonJS `require()` and `module`. ([#24])
+
 ### Changed
 
 - Built-in classes can no longer be instanted directly; their constructors have
   been marked as private. ([#23])
 
 [#23]: https://github.com/pastelmind/kolmafia-types/pull/23
+[#24]: https://github.com/pastelmind/kolmafia-types/pull/24
 
 ## [0.1.0] - 2021-04-05
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint": "gts lint",
     "fix": "gts fix",
-    "test": "ts-node run-tests.ts",
+    "test": "ts-node --project tsconfig.test.json run-tests.ts",
     "posttest": "npm run lint"
   },
   "repository": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -560,4 +560,21 @@ declare global {
     /** Attack element */
     readonly attackElement: Element;
   }
+
+  // eslint-disable-next-line no-var
+  var require: RhinoRequire;
+  // eslint-disable-next-line no-var
+  var module: RhinoModule;
+}
+
+interface RhinoRequire {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (id: string): any;
+  main: RhinoModule | undefined;
+}
+
+interface RhinoModule {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  exports: any;
+  id: string;
 }

--- a/test-d/global.test-d.ts
+++ b/test-d/global.test-d.ts
@@ -243,3 +243,18 @@ new Stat();
 new Thrall();
 // @ts-expect-error KoLmafia built-ins cannot be directly instantiated
 new Vykea();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+expectType<any>(require('foo'));
+expectError(require());
+if (require.main) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expectType<any>(require.main.exports);
+  expectType<string>(require.main.id);
+} else {
+  expectType<undefined>(require.main);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+expectType<any>(module.exports);
+expectType<string>(module.id);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
-    "resolveJsonModule": true
-  }
+    // We don't want @types/node to interfere with our own types (e.g. require())
+    "types": []
+  },
+  "include": ["src", "test-d"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "gts/tsconfig-google.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
+  "exclude": ["src", "test-d"]
+}


### PR DESCRIPTION
Add type definitions for `require()` and `module`, two values that are provided by Rhino for CommonJS modules. While both are of little use in TypeScript code, `require.main.id` can be used to access the current script's file name.

I intentionally sprinkled `any` throughout this because `module.exports` can have arbitrary shapes, and I'm not sure if `unknown` would be appropriate.