### PR TITLE
test: Use typingsFile option of tsd()

### DIFF
--- a/run-tests.ts
+++ b/run-tests.ts
@@ -1,38 +1,16 @@
-import {promises} from 'fs';
 import tsd from 'tsd';
 import formatter from 'tsd/dist/lib/formatter';
 
-const {readFile, writeFile} = promises;
-
-const PACKAGE_JSON = './package.json';
-
-async function main() {
-  // tsd 0.14.0 does not support typesVersions key, despite being powered by
-  // TypeScript 4.1
-  // Thus, we must temporarily modify package.json
-  const pkgText = await readFile(PACKAGE_JSON, 'utf8');
-  const pkg: typeof import('./package.json') = JSON.parse(pkgText);
-
-  const tempPkg = {
-    ...pkg,
-    types: Object.values(Object.values(pkg.typesVersions)[0])[0][0],
-  };
-  await writeFile(PACKAGE_JSON, JSON.stringify(tempPkg));
-
+(async () => {
   try {
-    const diagnostics = await tsd();
+    // tsd 0.17.0 does not support `typingsFile` as a CLI argument yet
+    const diagnostics = await tsd({
+      cwd: __dirname,
+      typingsFile: 'src/index.d.ts',
+    });
     if (diagnostics.length > 0) {
       throw new Error(formatter(diagnostics));
     }
-  } finally {
-    // Restore previous package.json
-    await writeFile(PACKAGE_JSON, pkgText);
-  }
-}
-
-(async () => {
-  try {
-    await main();
   } catch (e) {
     console.error(e);
     process.exitCode = 1;


### PR DESCRIPTION
Back when I added the TypeScript 4.1+ requirement in #20, tsd did not support specifying a custom typings file. I had to temporarily add a `types` filed to `package.json` while testing:
https://github.com/pastelmind/kolmafia-types/blob/895de75f4332fea07b1f54cd0f9cb691cd7c0fd2/run-tests.ts#L10-L20

Obviously, this was very hacky.

Now that [tsd 0.15.0+ supports the `typingsFile` option](https://github.com/SamVerschueren/tsd/releases/tag/v0.15.0), we can simply use it instead.

Note: tsd does not expose `typingsFile` as a CLI argument yet, but [a related PR is awaiting integration](https://github.com/SamVerschueren/tsd/pull/93). Let's hope it gets merged soon.