### PR TITLE
feat: Add combat filter callbacks

### DIFF
--- a/test-d/kolmafia.test-d.ts
+++ b/test-d/kolmafia.test-d.ts
@@ -3,7 +3,7 @@
  */
 
 import {expectError, expectType} from 'tsd';
-import {isDarkMode, max, min} from '../src';
+import {adv1, adventure, isDarkMode, max, min, runCombat} from '../src';
 
 expectType<boolean>(isDarkMode());
 
@@ -26,3 +26,43 @@ min();
 expectError(min('foo bar'));
 expectError(min(null));
 expectError(min(undefined));
+
+expectType<boolean>(adventure(Location.get('someplace'), 1));
+expectType<boolean>(adventure(1, Location.get('someplace')));
+expectType<boolean>(adventure(Location.get('someplace'), 1, 'combat filter'));
+expectType<boolean>(adventure(1, Location.get('someplace'), 'combat filter'));
+expectType<boolean>(
+  adventure(
+    Location.get('someplace'),
+    1,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (round: number, monster: Monster, page: string) => 'macro'
+  )
+);
+expectType<boolean>(
+  adventure(
+    1,
+    Location.get('someplace'),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (round: number, monster: Monster, page: string) => 'macro'
+  )
+);
+
+expectType<boolean>(adv1(Location.get('foo'), -1, 'macro'));
+expectType<boolean>(
+  adv1(
+    Location.get('foo'),
+    -1,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (round: number, monster: Monster, page: string) => 'macro'
+  )
+);
+
+expectType<string>(runCombat());
+expectType<string>(runCombat('combat filter'));
+expectType<string>(
+  runCombat(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (round: number, monster: Monster, page: string) => 'macro'
+  )
+);


### PR DESCRIPTION
As of KoLmafia [r20738](https://kolmafia.us/threads/20738-javascript-combat-macros-can-now-be-executed-with-access-to-their-parent-scope-tested.26079/), `adv1()`, `adventure()`, and `runCombat()` accept a JavaScript callback as the combat filter argument.

Also add tests for these type definitions.