### PR TITLE
feat!: Reorganize string functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ List of sections:
 
 ## [Unreleased]
 
+### Added
+
+- JSDoc comments for all string-manipulating functions ([#40])
+
+### Changed
+
+- String-manipulating functions that have equivalent JavaScript builtins are
+  marked as `@deprecated`. This includes `indexOf()`, `lastIndexOf()`,
+  `length()`, `splitString()`, `startsWith()`, and `substring()`. ([#40])
+
+### Removed
+
+- `append()`, `insert()`, `replace()`, and `setLength()` are removed. Although
+  KoLmafia provides these functions, they require an ASH buffer as argument.
+  Since ASH buffers cannot be constructed in JavaScript, these functions are
+  effectively unusable. ([#40])
+
+[#40]: https://github.com/pastelmind/kolmafia-types/pull/40
+
 ## [0.1.2] - 2021-06-23
 
 ### Added

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,3 +3,4 @@ export * from './kolmafia';
 export * from './kolmafia-cargo-cultist-shorts';
 export * from './kolmafia-math';
 export * from './kolmafia-modifier';
+export * from './kolmafia-string';

--- a/src/kolmafia-string.d.ts
+++ b/src/kolmafia-string.d.ts
@@ -1,0 +1,184 @@
+/**
+ * @file KoLmafia functions for manipulating strings.
+ * Most of them are marked as deprecated since they can be replaced by
+ * JavaScript built-ins.
+ */
+
+/**
+ * Returns the character in a string at the given index.
+ * @deprecated Use `String.prototype.charAt()` instead.
+ * @param source
+ * @param index
+ * @return Character at the specified `index`
+ */
+export function charAt(source: string, index: number): string;
+
+/**
+ * Checks if the `source` string contains the `search` substring.
+ * @deprecated Use `String.prototype.includes()` instead
+ * @param source Source string to search in
+ * @param search Target substring to search for
+ * @return Whether `source` contains `search`
+ */
+export function containsText(source: string, search: string): boolean;
+
+/**
+ * Checks if the `source` string ends with the given `suffix`.
+ * @deprecated Use `String.prototype.endsWith()` instead.
+ * @param source Source string to search in
+ * @param suffix Suffix to search for
+ * @return Whether the end of `source` matches `prefix`
+ */
+export function endsWith(source: string, suffix: string): boolean;
+
+// TODO: Deprecate this when Rhino implements `String.prototype.matchAll()`.
+// See https://github.com/mozilla/rhino/issues/933
+/**
+ * Finds all matches of `regex` against the `source` string and return an object
+ * containing every match result.
+ * @param source Source string to search in
+ * @param regex Java regular expression pattern
+ *    (_This does **not** use JavaScript's regular expressions_)
+ * @return Object whose keys are integers (0, 1, ...) and values are match
+ *    results. Each match result is a object whose keys are integers and values
+ *    are strings. The first item (index 0) in a match result is the whole
+ *    substring in the current match; any subsequent items correspond to
+ *    capturing groups within the `regex`.
+ */
+export function groupString(
+  source: string,
+  regex: string
+): {[key: number]: {[group: number]: string}};
+
+/**
+ * Searches for the first occurrence of `substring` within the `source` string
+ * and returns its position.
+ * @deprecated Use `String.prototype.indexOf()` instead.
+ * @param source Source string to search in
+ * @param substring Substring to search for
+ * @return Index of substring, or -1 if the substring is not found
+ */
+export function indexOf(source: string, substring: string): number;
+
+/**
+ * Searches for the first occurrence of `substring` within the `source` string,
+ * starting at the index `start`, and returns its position.
+ * @deprecated Use `String.prototype.indexOf()` instead.
+ * @param source Source string to search in
+ * @param substring Substring to search for
+ * @param start Index to start searching at
+ * @return Index of substring, or -1 if the substring is not found
+ */
+export function indexOf(
+  source: string,
+  substring: string,
+  start: number
+): number;
+
+/**
+ * Searches for the last occurrence of `substring` within the `source` string
+ * and returns its position.
+ * @deprecated Use `String.prototype.lastIndexOf()` instead.
+ * @param source Source string to search in
+ * @param substring Substring to search for
+ * @return Index of substring, or -1 if the substring is not found
+ */
+export function lastIndexOf(source: string, substring: string): number;
+
+/**
+ * Searches for the last occurrence of `substring` within the `source` string,
+ * up to the index `start`, and returns its position.
+ * @deprecated Use `String.prototype.lastIndexOf()` instead.
+ * @param source Source string to search in
+ * @param substring Substring to search for
+ * @param finish Index of last character to attempt a match
+ * @return Index of substring, or -1 if the substring is not found
+ */
+export function lastIndexOf(
+  source: string,
+  substring: string,
+  finish: number
+): number;
+
+/**
+ * Returns the number of characters in a string.
+ * @deprecated Use the `.length` property on string values instead.
+ * @param string
+ * @return Length of the given `string`
+ */
+export function length(string: string): number;
+
+// TODO: Deprecate this when Rhino implements `String.prototype.replaceAll()`.
+// See https://github.com/mozilla/rhino/issues/944
+/**
+ * Replace all occurrences of `find` in `source` with `replacement`.
+ * @param source String to search in
+ * @param find Substring to search for
+ * @param replacement Replacement string
+ * @return Modified string
+ */
+export function replaceString(
+  source: string,
+  find: string,
+  replacement: string
+): string;
+
+/**
+ * Splits the `string` at line breaks into multiple fragments.
+ *
+ * Note: This uses OS-specific line breaks. On Windows, it will split `\r\n` but
+ * ignore `\n`.
+ * @deprecated Use `String.prototype.split()` instead.
+ * @param string String to split
+ * @return Array of string fragments
+ */
+export function splitString(string: string): string[];
+
+/**
+ * Splits the `string` into multiple fragments, using `regex` as the deliminter.
+ * @deprecated Use `String.prototype.split()` instead.
+ * @param string String to split
+ * @param regex Java regular expression pattern
+ *    (_This does **not** use JavaScript's regular expressions_)
+ * @return Array of string fragments
+ */
+export function splitString(string: string, regex: string): string[];
+
+/**
+ * Checks if the `source` string starts with the given `prefix`.
+ * @deprecated Use `String.prototype.startsWith()` instead.
+ * @param source Source string to search in
+ * @param prefix Prefix to search for
+ * @return Whether the beginning of `source` matches `prefix`
+ */
+export function startsWith(source: string, prefix: string): boolean;
+
+/**
+ * Extracts a substring of `source`, starting at index `start` up to the end of
+ * `source`.
+ * @deprecated Use `String.prototype.slice()` or `String.prototype.substring()`
+ *    instead.
+ * @param source Source string to slice
+ * @param start Index at which to begin slicing. If this is less than 0 or
+ *    greater than the length of `source`, this aborts the script.
+ * @return Extracted substring
+ */
+export function substring(source: string, start: number): string;
+
+/**
+ * Extracts a substring of `source`, starting at index `start` up to (but not
+ * including) `finish`.
+ * @deprecated Use `String.prototype.slice()` or `String.prototype.substring()`
+ *    instead.
+ * @param source Source string to slice
+ * @param start Index at which to begin slicing. If this is less than 0 or
+ *    greater than the length of `source`, this aborts the script.
+ * @param finish Index at which to end slicing. If this is less than 0, greater
+ *    than the length of `source`, or less than `start`, this aborts the script.
+ * @return Extracted substring
+ */
+export function substring(
+  source: string,
+  start: number,
+  finish: number
+): string;

--- a/src/kolmafia.d.ts
+++ b/src/kolmafia.d.ts
@@ -371,18 +371,6 @@ export function appearanceRates(
 ): {[monster: string]: number};
 
 /**
- * **This function cannot be used in JavaScript due to limitations of KoLmafia's
- * type system.**
- *
- * Returns a buffer containing `original` with `add` tacked on to the end.
- * @deprecated
- * @param original Buffer to add to
- * @param add String to add on
- * @return Modified buffer
- */
-export function append(original: string, add: string): string;
-
-/**
  * Attacks with your weapon inside a consult script.
  * @return HTML response from the attack attempt
  */
@@ -774,14 +762,6 @@ export function candyForTier(tier: number, flags: number): Item[];
 export function changeMcd(level: number): boolean;
 
 /**
- * Returns the character in a string at the given index.
- * @deprecated Use `String.prototype.charAt()` instead.
- * @param source
- * @param index
- */
-export function charAt(source: string, index: number): string;
-
-/**
  * Posts a chat message to the "/clan" channel.
  * This does nothing if the player has not passed the Literacy test, or if
  * scripted chat has been disabled due to improper use.
@@ -903,15 +883,6 @@ export function combatManaCostModifier(): number;
  * For example, if your total Combat Rate modifier is -15%, this returns -15.0.
  */
 export function combatRateModifier(): number;
-
-/**
- * Checks if the `source` string contains the `search` substring.
- * @deprecated Use `String.prototype.includes()` instead
- * @param source Source string to search in
- * @param search Target substring to search for
- * @return Whether `source` contains `search`
- */
-export function containsText(source: string, search: string): boolean;
 
 /**
  * Visits the Council of Loathing.
@@ -1437,14 +1408,6 @@ export function emptyCloset(): boolean;
  *    The special keyword `"all"` enables _all_ ASH functions.
  */
 export function enable(functionNames: string): void;
-
-/**
- * Checks if the `source` string ends with the given `suffix`.
- * @deprecated Use `String.prototype.endsWith()` instead
- * @param source Source string to search in
- * @param suffix Suffix to search for
- */
-export function endsWith(source: string, suffix: string): boolean;
 
 /**
  * Puts the given familiar in your {@link https://kol.coldfront.net/thekolwiki/index.php/Crown_of_Thrones Crown of Thrones}.
@@ -1994,10 +1957,6 @@ export function getWorkshed(): Item;
 
 export function gnomadsAvailable(): boolean;
 export function goalExists(check: string): boolean;
-export function groupString(
-  string: string,
-  regex: string
-): {[key: number]: {[key: number]: string}};
 
 /**
  * Checks if your character can access the guild.
@@ -2045,11 +2004,9 @@ export function inaccessibleReason(master: Coinmaster): string;
  * @version r20779
  */
 export function inCasual(): boolean;
-export function indexOf(source: string, search: string): number;
-export function indexOf(source: string, search: string, start: number): number;
+
 export function inebrietyLimit(): number;
 export function initiativeModifier(): number;
-export function insert(buffer: string, index: number, s: string): string;
 export function isAccessible(master: Coinmaster): boolean;
 export function isBanished(arg: Monster): boolean;
 export function isCoinmasterItem(item: Item): boolean;
@@ -2101,17 +2058,10 @@ export function jumpChance(arg: Location, init: number, ml: number): number;
 export function knollAvailable(): boolean;
 export function lastChoice(): number;
 export function lastDecision(): number;
-export function lastIndexOf(source: string, search: string): number;
-export function lastIndexOf(
-  source: string,
-  search: string,
-  start: number
-): number;
 export function lastItemMessage(): string;
 export function lastMonster(): Monster;
 export function lastSkillMessage(): string;
 export function leetify(string: string): string;
-export function length(string: string): number;
 export function lightningCost(skill: Skill): number;
 export function limitMode(): string;
 export function loadHtml(string: string): string;
@@ -2322,22 +2272,6 @@ export function renameProperty(
   oldNameValue: string,
   newNameValue: string
 ): boolean;
-export function replace(
-  buffer: string,
-  start: number,
-  finish: number,
-  s: string
-): string;
-export function replaceString(
-  source: string,
-  searchValue: string,
-  replaceValue: string
-): string;
-export function replaceString(
-  source: string,
-  searchValue: string,
-  replaceValue: string
-): string;
 export function repriceShop(priceValue: number, itemValue: Item): boolean;
 export function repriceShop(
   priceValue: number,
@@ -2414,7 +2348,6 @@ export function sessionLogs(
 ): string[];
 export function setAutoAttack(attackValue: number): void;
 export function setAutoAttack(attackValue: string): void;
-export function setLength(buffer: string, i: number): void;
 export function setLocation(location: Location): void;
 export function setProperty(nameValue: string, value: string): void;
 export function shopAmount(arg: Item): number;
@@ -2423,9 +2356,6 @@ export function shopPrice(item: Item): number;
 export function slashCount(arg: Item): number;
 export function soulsauceCost(skill: Skill): number;
 export function spleenLimit(): number;
-export function splitString(string: string): string[];
-export function splitString(string: string, regex: string): string[];
-export function startsWith(source: string, prefix: string): boolean;
 export function stashAmount(arg: Item): number;
 export function statBonusToday(): Stat;
 export function statBonusTomorrow(): Stat;
@@ -2434,12 +2364,6 @@ export function stillsAvailable(): number;
 export function stopCounter(label: string): void;
 export function storageAmount(arg: Item): number;
 export function stunSkill(): Skill;
-export function substring(source: string, start: number): string;
-export function substring(
-  source: string,
-  start: number,
-  finish: number
-): string;
 export function svnAtHead(project: string): boolean;
 export function svnExists(project: string): boolean;
 export function svnInfo(script: string): {


### PR DESCRIPTION
- Move string functions into `kolmafia-string.d.ts` (this does not affect users)
- Deprecate all string functions that can be replaced with JavaScript builtins
- Remove all functions that take an ASH buffer as argument, as they are effectively unusable from JavaScript.
  This includes:
  - `append()`
  - ~~`delete()`~~ was never exported to begin with
  - `insert()`
  - `replace()`
  - `setLength()`
- Add JSDoc comments for string functions