### PR TITLE
feat!: update and fix cargo shorts functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ List of sections:
 ### Added
 
 - JSDoc comments for all string-manipulating functions ([#40])
+- JSDoc comments for all Cargo Cultist Shorts functions ([#41])
 
 ### Changed
 
@@ -34,7 +35,13 @@ List of sections:
   Since ASH buffers cannot be constructed in JavaScript, these functions are
   effectively unusable. ([#40])
 
+### Fixed
+
+- Variants of `pickPocket()` that accept an `Effect`, `Item`, or `Stat` now
+  return a `boolean`. ([#41])
+
 [#40]: https://github.com/pastelmind/kolmafia-types/pull/40
+[#41]: https://github.com/pastelmind/kolmafia-types/pull/41
 
 ## [0.1.2] - 2021-06-23
 

--- a/src/kolmafia-cargo-cultist-shorts.d.ts
+++ b/src/kolmafia-cargo-cultist-shorts.d.ts
@@ -5,8 +5,8 @@
 import './global';
 
 /**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will
- * result in a fight with the `monster`.
+ * Returns an unopened pocket number in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will result in a fight with the `monster`.
  * @param monster Monster to search for
  * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
  *    available pockets contain the `monster`
@@ -14,8 +14,8 @@ import './global';
 export function availablePocket(monster: Monster): number;
 
 /**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
- * the most turns of `effect`.
+ * Returns an unopened pocket number in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will give the most turns of `effect`.
  * @param effect Effect to search for
  * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
  *    available pockets contain the `effect`
@@ -23,8 +23,8 @@ export function availablePocket(monster: Monster): number;
 export function availablePocket(effect: Effect): number;
 
 /**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
- * the largest number of `item`.
+ * Returns an unopened pocket number in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will give the largest number of `item`.
  * @param item Item to look for
  * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
  *    available pockets contain the `item`
@@ -32,8 +32,8 @@ export function availablePocket(effect: Effect): number;
 export function availablePocket(item: Item): number;
 
 /**
- * Returns an unopened pocket number in your Cargo Cultist Shorts that will give
- * the most substats for the `stat`.
+ * Returns an unopened pocket number in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will give the most substats for the `stat`.
  * @param stat Stat to look for
  * @return Pocket number (integer between 1 and 666, inclusive), or 0 if no
  *    available pockets give the `stat`
@@ -43,40 +43,287 @@ export function availablePocket(stat: Stat): number;
 /**
  * Returns an object whose keys are pocket numbers (converted to strings) of all
  * pockets in the {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
- * that give effects. This includes both used and unused pockets.
+ * that give effects.
+ * This includes both used and unused pockets.
  */
-export function effectPockets(): {[key: number]: true};
+export function effectPockets(): {[pocket: number]: true};
 
-export function itemPockets(): {[key: number]: boolean};
-export function jokePockets(): {[key: number]: boolean};
-export function meatPockets(): {[key: number]: number};
-export function monsterPockets(): {[key: number]: boolean};
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * pockets in the {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that give items.
+ * This includes both used and unused pockets.
+ */
+export function itemPockets(): {[pocket: number]: true};
 
-export function pickPocket(arg: number): boolean;
-export function pickPocket(arg: Monster): boolean;
-export function pickPocket(arg: Effect): {[effect: string]: number};
-export function pickPocket(arg: Item): {[item: string]: number};
-export function pickPocket(arg: Stat): {[stat: string]: number};
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * pockets in the {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contain a joke and give the {@link https://kol.coldfront.net/thekolwiki/index.php/Joke-Mad Joke-Mad}
+ * effect.
+ * This includes both used and unused pockets.
+ */
+export function jokePockets(): {[pocket: number]: true};
 
-export function pickedPockets(): {[key: number]: boolean};
-export function pickedScraps(): {[key: number]: boolean};
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contain meat and puzzles, sorted by meat amount in ascending order.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function meatPockets(): {[index: number]: number};
 
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * pockets in the {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contain a monster.
+ * This includes both used and unused pockets.
+ */
+export function monsterPockets(): {[pocket: number]: true};
+
+/**
+ * Picks a pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Whether the pocket was successfully picked
+ */
+export function pickPocket(pocket: number): boolean;
+
+/**
+ * Picks an unopened pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will result in a fight with the `monster`.
+ * @param monster Monster to search for
+ * @return Whether the pocket was successfully picked
+ */
+export function pickPocket(monster: Monster): boolean;
+
+/**
+ * Picks an unopened pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will give the most turns of `effect`.
+ * @param effect Effect to search for
+ * @return Whether the pocket was successfully picked
+ */
+export function pickPocket(effect: Effect): boolean;
+
+/**
+ * Picks an unopened pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will give the greatest number of `item`.
+ * @param item Item to search for
+ * @return Whether the pocket was successfully picked
+ */
+export function pickPocket(item: Item): boolean;
+
+/**
+ * Picks an unopened pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that will give the most amount of substats for the `stat`.
+ * @param stat Stat to search for
+ * @return Whether the pocket was successfully picked
+ */
+export function pickPocket(stat: Stat): boolean;
+
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * picked pockets in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ */
+export function pickedPockets(): {[pocket: number]: true};
+
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * picked pockets in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contains a scrap (number) puzzle.
+ * This does not include waterlogged cipher puzzles or joke pockets.
+ */
+export function pickedScraps(): {[pocket: number]: true};
+
+/**
+ * Returns an object containing the names and number of turns of all effects
+ * given by the `pocket` in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Object whose keys are names of all effects given by the `pocket`,
+ *    and values are the number of turns of each effect given.
+ *    If the `pocket` does not give any effect, returns an empty object.
+ */
 export function pocketEffects(pocket: number): {[effect: string]: number};
+
+/**
+ * Returns an object containing the names and quantity of all items given by
+ * the `pocket` in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Object whose keys are names of all items given by the `pocket`, and
+ *    values are the number of each item given.
+ *    If the `pocket` does not give any item, returns an empty object.
+ */
 export function pocketItems(pocket: number): {[item: string]: number};
+
+/**
+ * Returns the joke message that would be given from a joke `pocket` in your
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Joke message from the pocket, or an empty string if the `pocket` does
+ *    not contain a joke
+ */
 export function pocketJoke(pocket: number): string;
-export function pocketMeat(pocket: number): {[key: number]: string};
+
+// pocketMeat(), pocketPoem(), and pocketScrap() are effectively the same
+// function, as they contain exactly the same code.
+/**
+ * Returns the contents of a meat puzzle pocket, a number puzzle pocket, or a
+ * waterlogged poem pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ *
+ * - If `pocket` is a meat puzzle pocket, the object contains a single key,
+ *   which is the amount of meat given (as a string). The corresponding value
+ *   is the puzzle message given together with the meat.
+ * - If `pocket` is a number puzzle pocket, the object contains a single key,
+ *   which is an internal number that KoLmafia uses to track the puzzle. The
+ *   corresponding value is the syllable you saw when you last picked the
+ *   `pocket`, or an empty string if you haven't picked it yet.
+ * - If `pocket` is a waterlogged cipher puzzle pocket, the object contains a
+ *   single key, which is an internal number that KoLmafia uses to track the
+ *   puzzle. The corresponding value is a poem fragment string.
+ *
+ * Note: This is effectively identical to {@link pocketPoem pocketPoem()} and
+ * {@link pocketScrap pocketScrap()}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Object that represents the contents of a puzzle pocket, or an empty
+ *    object if the `pocket` is not a puzzle pocket.
+ */
+export function pocketMeat(pocket: number): {[meat: number]: string};
+
+/**
+ * Returns the monster that is contained in the `pocket` in your
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Monster in the `pocket`, or `none` if the `pocket` does not contain a
+ *    monster
+ */
 export function pocketMonster(pocket: number): Monster;
+
+/**
+ * Returns the contents of a meat puzzle pocket, a number puzzle pocket, or a
+ * waterlogged poem pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ *
+ * - If `pocket` is a meat puzzle pocket, the object contains a single key,
+ *   which is the amount of meat given (as a string). The corresponding value
+ *   is the puzzle message given together with the meat.
+ * - If `pocket` is a number puzzle pocket, the object contains a single key,
+ *   which is an internal number that KoLmafia uses to track the puzzle. The
+ *   corresponding value is the syllable you saw when you last picked the
+ *   `pocket`, or an empty string if you haven't picked it yet.
+ * - If `pocket` is a waterlogged cipher puzzle pocket, the object contains a
+ *   single key, which is an internal number that KoLmafia uses to track the
+ *   puzzle. The corresponding value is a poem fragment string.
+ *
+ * Note: This is effectively identical to {@link pocketMeat pocketMeat()} and
+ * {@link pocketScrap pocketScrap()}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Object that represents the contents of a puzzle pocket, or an empty
+ *    object if the `pocket` is not a puzzle pocket.
+ */
 export function pocketPoem(pocket: number): {[key: number]: string};
+
+/**
+ * Returns the contents of a meat puzzle pocket, a number puzzle pocket, or a
+ * waterlogged poem pocket in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ *
+ * - If `pocket` is a meat puzzle pocket, the object contains a single key,
+ *   which is the amount of meat given (as a string). The corresponding value
+ *   is the puzzle message given together with the meat.
+ * - If `pocket` is a number puzzle pocket, the object contains a single key,
+ *   which is an internal number that KoLmafia uses to track the puzzle. The
+ *   corresponding value is the syllable you saw when you last picked the
+ *   `pocket`, or an empty string if you haven't picked it yet.
+ * - If `pocket` is a waterlogged cipher puzzle pocket, the object contains a
+ *   single key, which is an internal number that KoLmafia uses to track the
+ *   puzzle. The corresponding value is a poem fragment string.
+ *
+ * Note: This is effectively identical to {@link pocketMeat pocketMeat()} and
+ * {@link pocketPoem pocketPoem()}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Object that represents the contents of a puzzle pocket, or an empty
+ *    object if the `pocket` is not a puzzle pocket.
+ */
 export function pocketScrap(pocket: number): {[key: number]: string};
+
+/**
+ * Returns an object containing the names and substat amounts of all stats
+ * given by the `pocket` in your {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}.
+ * @param pocket Pocket number (integer between 1 and 666, inclusive)
+ * @return Object whose keys are names of all stats given by the `pocket`, and
+ *    values are the amount of substat given for each stat.
+ *    If the `pocket` does not give any stat, returns an empty object.
+ */
 export function pocketStats(pocket: number): {[stat: string]: number};
 
-export function poemPockets(): {[key: number]: number};
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contain a waterlogged cipher poem puzzle, sorted in the order of the
+ * poem.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function poemPockets(): {[pocket: number]: number};
 
-export function potentialPockets(arg: Monster): {[key: number]: number};
-export function potentialPockets(arg: Effect): {[key: number]: number};
-export function potentialPockets(arg: Item): {[key: number]: number};
-export function potentialPockets(arg: Stat): {[key: number]: number};
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contain the `monster`.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function potentialPockets(monster: Monster): {[key: number]: number};
 
-export function restorationPockets(): {[key: number]: boolean};
-export function scrapPockets(): {[key: number]: number};
-export function statsPockets(): {[key: number]: boolean};
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that give the `effect`, sorted by the number of turns of the effect given in
+ * descending order.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function potentialPockets(effect: Effect): {[key: number]: number};
+
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that give the `item`, sorted by the number of `item` given in descending
+ * order.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function potentialPockets(item: Item): {[key: number]: number};
+
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that give substats for the `stat`, sorted by the amount of `stat` given in
+ * descending order.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function potentialPockets(stat: Stat): {[key: number]: number};
+
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * pockets in the {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that restore all your HP and MP.
+ * This includes both used and unused pockets.
+ */
+export function restorationPockets(): {[pocket: number]: true};
+
+/**
+ * Returns an object whose _values_ are pocket numbers of all pockets in the
+ * {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that contain a scrap (number) puzzle, sorted in the order of syllables.
+ * (The keys merely serve as indices.)
+ * This includes both used and unused pockets.
+ */
+export function scrapPockets(): {[pocket: number]: number};
+
+/**
+ * Returns an object whose keys are pocket numbers (converted to strings) of all
+ * pockets in the {@link https://kol.coldfront.net/thekolwiki/index.php/Cargo_Cultist_Shorts Cargo Cultist Shorts}
+ * that give stats.
+ * This includes both used and unused pockets.
+ */
+export function statsPockets(): {[pocket: number]: true};

--- a/test-d/kolmafia-cargo-cultist-shorts.test-d.ts
+++ b/test-d/kolmafia-cargo-cultist-shorts.test-d.ts
@@ -35,23 +35,23 @@ expectType<number>(availablePocket(Item.get('foo')));
 expectType<number>(availablePocket(Stat.get('foo')));
 
 expectType<Record<number, true>>(effectPockets());
-expectType<Record<number, boolean>>(itemPockets());
-expectType<Record<number, boolean>>(jokePockets());
+expectType<Record<number, true>>(itemPockets());
+expectType<Record<number, true>>(jokePockets());
 expectType<Record<number, number>>(meatPockets());
-expectType<Record<number, boolean>>(monsterPockets());
+expectType<Record<number, true>>(monsterPockets());
 expectType<Record<number, number>>(poemPockets());
-expectType<Record<number, boolean>>(restorationPockets());
+expectType<Record<number, true>>(restorationPockets());
 expectType<Record<number, number>>(scrapPockets());
-expectType<Record<number, boolean>>(statsPockets());
+expectType<Record<number, true>>(statsPockets());
 
-expectType<Record<number, boolean>>(pickedPockets());
-expectType<Record<number, boolean>>(pickedScraps());
+expectType<Record<number, true>>(pickedPockets());
+expectType<Record<number, true>>(pickedScraps());
 
 expectType<boolean>(pickPocket(1234));
 expectType<boolean>(pickPocket(Monster.get('foo')));
-expectType<Record<string, number>>(pickPocket(Effect.get('foo')));
-expectType<Record<string, number>>(pickPocket(Item.get('foo')));
-expectType<Record<string, number>>(pickPocket(Stat.get('foo')));
+expectType<boolean>(pickPocket(Effect.get('foo')));
+expectType<boolean>(pickPocket(Item.get('foo')));
+expectType<boolean>(pickPocket(Stat.get('foo')));
 
 expectType<Record<string, number>>(pocketEffects(123));
 expectType<Record<string, number>>(pocketItems(123));


### PR DESCRIPTION
Add JSDoc comments for all functions that examine and manipulate pockets in the Cargo Cultist Shorts.

Also fix the return types of `pickPocket(effect)`, `pickPocket(item)`, and `pickPocket(stat)`.
