### PR TITLE
fix(zlib): push header to top, fix kmail() desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ List of sections:
 
 ## [Unreleased]
 
+### Fixed
+
+- ZLib: `kmail()` uses the correct JSDoc comment as tooltip. ([#45])
+
+[#45]: https://github.com/pastelmind/kolmafia-types/pull/45
+
 ## [0.2.0] - 2021-07-14
 
 ### Added

--- a/contrib/zlib.ash.d.ts
+++ b/contrib/zlib.ash.d.ts
@@ -1,4 +1,16 @@
 /**
+ * @file Type definition for Zlib, made by zarqon.
+ *
+ * - ASH script name: Zlib
+ * - ASH script version: r49
+ * - ASH script authors: zarqon
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/zlib-zarqons-useful-function-library.2072/
+ *  - Wiki page: https://wiki.kolmafia.us/index.php?title=Zlib
+ */
+
+/**
  * Returns the best familiar you own for a given type.
  *
  * If your `is_100_run` ZLib variable is anything other than `none`, this
@@ -21,19 +33,15 @@ export function bestFam(
     | 'water'
 ): Familiar;
 
+// Due to compatibility issues between ASH and JavaScript, only the 3-parameter
+// form of kmail() can be called from JavaScript.
 /**
- * @file Type definition for Zlib, made by zarqon.
- *
- * - ASH script name: Zlib
- * - ASH script version: r49
- * - ASH script authors: zarqon
- *
- * Links:
- *  - ASH script forum thread: https://kolmafia.us/threads/zlib-zarqons-useful-function-library.2072/
- *  - Wiki page: https://wiki.kolmafia.us/index.php?title=Zlib
+ * Sends a kmail (or gift message) to another player.
+ * @param recipent Target player ID or username
+ * @param message Kmail or gift message
+ * @param meat Amount of meat to send
  */
-
-export function kmail(to: string, message: string, meat: number): boolean;
+export function kmail(recipent: string, message: string, meat: number): boolean;
 
 /**
  * Attempts to obtain `qty` of `condition`, either by purchasing, pulling, or


### PR DESCRIPTION
- When I added `bestFam() in #36 (c3f00a4e36f3533dc89661d1c00e4ee1e53562c2), I accidentally placed it above the file header comment.
  This commit relocates the file header comment to the top of the file.
- Add JSDoc comment for `kmail()`, so that VS Code's tooltip no longer shows the file header comment as the tooltip.