### PR TITLE
feat!: update itemDropsArray()

### DIFF
--- a/src/kolmafia.d.ts
+++ b/src/kolmafia.d.ts
@@ -2052,10 +2052,46 @@ export function itemAmount(arg: Item): number;
 export function itemDropModifier(): number;
 export function itemDrops(): {[item: string]: number};
 export function itemDrops(arg: Monster): {[item: string]: number};
-export function itemDropsArray(): {drop: Item; rate: number; type: string}[];
-export function itemDropsArray(
-  monster: Monster
-): {drop: Item; rate: number; type: string}[];
+
+/**
+ * Indicates the item drop type.
+ *
+ * - Empty string (`''`) indicates a regular drop
+ * - `'0'` indicates items for which KoLmafia has no drop information
+ * - `'a'` indicates items that can be gained only with Steal Accordion
+ * - `'c'` indicates conditional drops (implies cannot be pickpocketed)
+ * - `'f'` indicates items that have a fixed drop rate
+ * - `'n'` indicates items that cannot be pickpocketed
+ * - `'p'` indicates items that can be gained only with pickpocket
+ */
+export type ItemDropType = '' | '0' | 'c' | 'n' | 'a' | 'f' | 'p';
+
+/**
+ * Information about an item dropped by a monster.
+ */
+export interface ItemDropEntry {
+  /** Item dropped */
+  drop: Item;
+  /** Base drop rate of the item in percent (ex: `15` means 15% drop chance) */
+  rate: number;
+  /** Item drop type */
+  type: ItemDropType;
+}
+
+/**
+ * Returns an array of records for items dropped by the current (or last)
+ * monster.
+ * @version r20827 Was buggy before this revision
+ */
+export function itemDropsArray(): ItemDropEntry[];
+
+/**
+ * Returns an array of records for items dropped by the `monster`.
+ * @param monster Monster to check
+ * @version r20827 Was buggy before this revision
+ */
+export function itemDropsArray(monster: Monster): ItemDropEntry[];
+
 export function itemDropsArray(
   arg: Monster
 ): {drop: Item; rate: number; type: string}[];


### PR DESCRIPTION
- Added JSDoc comments for `itemDropsArray()` and added a `@version` tag in response to a bugfix in [r20827](https://kolmafia.us/threads/20827-only-coerce-map-keys-for-javascript-not-values-js-object-keys-are-only-representable.26265/) (see https://kolmafia.us/threads/25638/post-163241)
- The return type of `itemDropsArray()` has been extracted as an interface named `ItemDropEntry`
- The type of the `type` field has been narrowed to a union type named `ItemDropType`. Its behavior is described in https://kolmafia.us/threads/3866/post-27220 (which is a bit out of date btw).